### PR TITLE
feat: add steampunk theme and shuffle control

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,405 +1,556 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Mr.FLENs Music Finder — Audius Library</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet" />
-  <style>
-    :root{
-      --color-primary:#5CF3FF;
-      --color-secondary:#9B5CFF;
-      --color-bg:#05060A;
-      --color-glass:rgba(255,255,255,0.06);
-      --color-text:#EAF4FF;
-      --color-muted:#8A96B3;
-    }
-    body{
-      background:var(--color-bg);
-      color:var(--color-text);
-      font-family:'Inter',system-ui,sans-serif;
-      margin:0;
-    }
-    header,footer,main{max-width:1100px;margin:auto}
-    .glass{
-      backdrop-filter:saturate(1.4) blur(12px);
-      background:var(--color-glass);
-      border:1px solid #ffffff11;
-      border-radius:16px;
-    }
-    .grid{display:grid;gap:16px}
-    input#search{
-      width:100%;
-      padding:12px 14px;
-      border-radius:12px;
-      border:1px solid #ffffff22;
-      background:#0b1020;
-      color:var(--color-text);
-      outline:none;
-    }
-    .track-card{
-      display:grid;
-      grid-template-columns:72px 1fr auto auto;
-      gap:12px;
-      padding:12px;
-      align-items:center;
-    }
-    .track-card img{border-radius:10px}
-    .track-card .btn{opacity:0;transition:opacity .2s}
-    .track-card:hover .btn{opacity:1}
-    .btn{
-      display:inline-block;
-      text-decoration:none;
-      border:1px solid var(--color-primary);
-      color:var(--color-primary);
-      padding:8px 12px;
-      border-radius:10px;
-      background:transparent;
-      cursor:pointer;
-    }
-    .btn:hover{background:var(--color-secondary);color:#05060A}
-    .playlist-card{
-      display:grid;
-      grid-template-columns:72px 1fr;
-      gap:12px;
-      padding:12px;
-      align-items:center;
-      cursor:pointer;
-      text-decoration:none;
-      color:inherit;
-
-    }
-    .playlist-card img{border-radius:10px}
-    .pill{
-      padding:2px 8px;
-      border:1px solid #ffffff22;
-      border-radius:999px;
-      font-size:12px;
-      opacity:.8;
-    }
-    .row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-    .chip{
-      padding:4px 10px;
-      border:1px solid var(--color-muted);
-      border-radius:20px;
-      background:transparent;
-      color:var(--color-muted);
-      cursor:pointer;
-    }
-    .chip:hover{color:var(--color-secondary);border-color:var(--color-secondary)}
-    .chip.active{background:var(--color-primary);color:#05060A;border-color:var(--color-primary)}
-    .carousel{display:flex;gap:16px;overflow-x:auto;padding-bottom:4px}
-    .featured img{width:100%;height:200px;object-fit:cover;border-radius:12px}
-  </style>
-</head>
-<body>
-  <header class="glass grid" style="padding:12px 16px;margin:16px;">
-    <div class="row" style="justify-content:space-between;align-items:center;">
-      <div class="row"><h1 style="margin:0">🎶 Mr.FLENs Music Finder</h1><span class="pill">Audius+SC</span></div>
-      <button id="login" class="pill" style="cursor:pointer;background:#0000">Login</button>
-    </div>
-    <input id="search" placeholder="Search tracks (Ctrl/⌘-K)" autocomplete="off" />
-    <div id="genres" class="row"></div>
-  </header>
-
-  <main id="results" class="grid" style="padding:0 16px 140px;"></main>
-
-  <footer class="glass" style="position:fixed;left:0;right:0;bottom:0;padding:8px;margin:16px;display:grid;gap:8px;">
-    <div class="row" style="justify-content:space-between;">
-      <span id="queueLabel">Queue: 0</span>
-      <div class="row" style="gap:4px;">
-        <button id="next" class="btn">⏭</button>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Mr.FLENs Music Finder — Audius Library</title>
+    <link
+      rel="icon"
+      href="https://audius-content-6.cultur3stake.com/content/01K0PYMD8X6ZA6JNCDWMWD4510/480x480.jpg"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-primary: #c97c1a;
+        --color-secondary: #8b5e2e;
+        --color-bg: #1a0f0a;
+        --color-glass: rgba(80, 56, 40, 0.6);
+        --color-text: #f5e6c4;
+        --color-muted: #b2947d;
+      }
+      body {
+        background: var(--color-bg);
+        color: var(--color-text);
+        font-family: "Cinzel", serif;
+        margin: 0;
+      }
+      header,
+      footer,
+      main {
+        max-width: 1100px;
+        margin: auto;
+      }
+      .glass {
+        backdrop-filter: saturate(1.2) blur(10px);
+        background: var(--color-glass);
+        border: 1px solid var(--color-secondary);
+        border-radius: 16px;
+        box-shadow: 0 0 10px #000;
+      }
+      .grid {
+        display: grid;
+        gap: 16px;
+      }
+      input#search {
+        width: 100%;
+        padding: 12px 14px;
+        border-radius: 12px;
+        border: 1px solid #ffffff22;
+        background: #0b1020;
+        color: var(--color-text);
+        outline: none;
+      }
+      .track-card {
+        display: grid;
+        grid-template-columns: 72px 1fr auto auto;
+        gap: 12px;
+        padding: 12px;
+        align-items: center;
+      }
+      .track-card img {
+        border-radius: 10px;
+      }
+      .track-card .btn {
+        opacity: 0;
+        transition: opacity 0.2s;
+      }
+      .track-card:hover .btn {
+        opacity: 1;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        border: 1px solid var(--color-primary);
+        color: var(--color-bg);
+        padding: 8px 12px;
+        border-radius: 10px;
+        background: var(--color-primary);
+        cursor: pointer;
+      }
+      .btn:hover {
+        background: var(--color-secondary);
+        color: var(--color-text);
+      }
+      .playlist-card {
+        display: grid;
+        grid-template-columns: 72px 1fr;
+        gap: 12px;
+        padding: 12px;
+        align-items: center;
+        cursor: pointer;
+        text-decoration: none;
+        color: inherit;
+      }
+      .playlist-card img {
+        border-radius: 10px;
+      }
+      .pill {
+        padding: 2px 8px;
+        border: 1px solid var(--color-secondary);
+        border-radius: 999px;
+        font-size: 12px;
+        background: var(--color-glass);
+      }
+      .row {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .chip {
+        padding: 4px 10px;
+        border: 1px solid var(--color-muted);
+        border-radius: 20px;
+        background: transparent;
+        color: var(--color-muted);
+        cursor: pointer;
+      }
+      .chip:hover {
+        color: var(--color-secondary);
+        border-color: var(--color-secondary);
+      }
+      .chip.active {
+        background: var(--color-primary);
+        color: #05060a;
+        border-color: var(--color-primary);
+      }
+      .carousel {
+        display: flex;
+        gap: 16px;
+        overflow-x: auto;
+        padding-bottom: 4px;
+      }
+      .featured img {
+        width: 100%;
+        height: 200px;
+        object-fit: cover;
+        border-radius: 12px;
+      }
+      .logo {
+        height: 40px;
+        width: 40px;
+        border-radius: 50%;
+        border: 2px solid var(--color-secondary);
+        box-shadow: 0 0 4px #000;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="glass grid" style="padding: 12px 16px; margin: 16px">
+      <div
+        class="row"
+        style="justify-content: space-between; align-items: center"
+      >
+        <div class="row">
+          <img
+            src="https://audius-content-6.cultur3stake.com/content/01K0PYMD8X6ZA6JNCDWMWD4510/480x480.jpg"
+            alt="Mr.FLEN logo"
+            class="logo"
+          />
+          <h1 style="margin: 0">Mr.FLENs Music Finder</h1>
+          <span class="pill">Audius+SC</span>
+        </div>
+        <button
+          id="login"
+          class="pill"
+          style="cursor: pointer; background: #0000"
+        >
+          Login
+        </button>
       </div>
-    </div>
-    <div id="playerContainer"><audio id="player" controls preload="none" style="width:100%"></audio></div>
-  </footer>
+      <input
+        id="search"
+        placeholder="Search tracks (Ctrl/⌘-K)"
+        autocomplete="off"
+      />
+      <div id="genres" class="row"></div>
+    </header>
 
-<script type="module">
-/**
- * Audius REST integration for Mr.FLENs Music Finder.
- *
- * This script uses the public Audius API to search tracks and
- * obtain stream URLs. It debounces search input and updates
- * the result grid dynamically. To customise the look and feel,
- * edit the CSS in the <style> block above.
- */
+    <main id="results" class="grid" style="padding: 0 16px 140px"></main>
 
-const AUDIUS_APP_NAME = "Mr.FLENs Music Finder";
-const AUDIUS_API_KEY  = "922e6edcae9856000bf6814a1ee5745bfb57734"; // public, read-only (ok in client)
-const MRFLEN_HANDLE   = "Mr.FLEN";
-const SOUNDCLOUD_CLIENT_ID = 'YOUR_SOUNDCLOUD_API_KEY';
-// BACKEND-ONLY (do NOT ship secrets to the browser):
-// const AUDIUS_API_SECRET = "YOUR_AUDIUS_API_SECRET";
+    <footer
+      class="glass"
+      style="
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        padding: 8px;
+        margin: 16px;
+        display: grid;
+        gap: 8px;
+      "
+    >
+      <div class="row" style="justify-content: space-between">
+        <span id="queueLabel">Queue: 0</span>
+        <div class="row" style="gap: 4px">
+          <button id="shuffle" class="btn">🔀</button>
+          <button id="next" class="btn">⏭</button>
+        </div>
+      </div>
+      <div id="playerContainer">
+        <audio id="player" controls preload="none" style="width: 100%"></audio>
+      </div>
+    </footer>
 
-async function pickHost(){
-  const res = await fetch('https://api.audius.co');
-  const { data } = await res.json();
-  return data[Math.floor(Math.random()*data.length)];
-}
+    <script type="module">
+      /**
+       * Audius REST integration for Mr.FLENs Music Finder.
+       *
+       * This script uses the public Audius API to search tracks and
+       * obtain stream URLs. It debounces search input and updates
+       * the result grid dynamically. To customise the look and feel,
+       * edit the CSS in the <style> block above.
+       */
 
-async function searchTracks(query){
-  const host = await pickHost();
-  const url  = `${host}/v1/tracks/search?query=${encodeURIComponent(query)}&app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
-  const res  = await fetch(url, { headers: { Accept:'application/json' } });
-  const json = await res.json();
-  return json.data || [];
-}
+      const AUDIUS_APP_NAME = "Mr.FLENs Music Finder";
+      const AUDIUS_API_KEY = "922e6edcae9856000bf6814a1ee5745bfb57734"; // public, read-only (ok in client)
+      const MRFLEN_HANDLE = "Mr.FLEN";
+      const SOUNDCLOUD_CLIENT_ID = "YOUR_SOUNDCLOUD_API_KEY";
+      // BACKEND-ONLY (do NOT ship secrets to the browser):
+      // const AUDIUS_API_SECRET = "YOUR_AUDIUS_API_SECRET";
 
-async function searchSoundCloud(query){
-  const url = `https://api.soundcloud.com/tracks?client_id=${SOUNDCLOUD_CLIENT_ID}&q=${encodeURIComponent(query)}&limit=20`;
-  const res = await fetch(url);
-  if(!res.ok) throw new Error('sc');
-  const json = await res.json();
-  return json.filter(t=>t.user && t.user.username === MRFLEN_HANDLE);
-}
+      async function pickHost() {
+        const res = await fetch("https://api.audius.co");
+        const { data } = await res.json();
+        return data[Math.floor(Math.random() * data.length)];
+      }
 
-async function streamUrl(trackId){
-  const host = await pickHost();
-  return `${host}/v1/tracks/${trackId}/stream?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
-}
+      async function searchTracks(query) {
+        const host = await pickHost();
+        const url = `${host}/v1/tracks/search?query=${encodeURIComponent(query)}&app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
+        const res = await fetch(url, {
+          headers: { Accept: "application/json" },
+        });
+        const json = await res.json();
+        return json.data || [];
+      }
 
-async function trendingTracks(genre){
-  const host = await pickHost();
-  const genreParam = genre ? `&genre=${encodeURIComponent(genre)}` : '';
-  const url = `${host}/v1/tracks/trending?limit=5${genreParam}&app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
-  const res = await fetch(url, { headers: { Accept:'application/json' } });
-  const json = await res.json();
-  return (json.data || []).map(normalizeAudiusTrack);
-}
+      async function searchSoundCloud(query) {
+        const url = `https://api.soundcloud.com/tracks?client_id=${SOUNDCLOUD_CLIENT_ID}&q=${encodeURIComponent(query)}&limit=20`;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error("sc");
+        const json = await res.json();
+        return json.filter((t) => t.user && t.user.username === MRFLEN_HANDLE);
+      }
 
-async function trendingPlaylists(){
-  const host = await pickHost();
-  const url = `${host}/v1/playlists/trending?limit=5&app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
-  const res = await fetch(url, { headers: { Accept:'application/json' } });
-  const json = await res.json();
-  return json.data || [];
-}
+      async function streamUrl(trackId) {
+        const host = await pickHost();
+        return `${host}/v1/tracks/${trackId}/stream?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
+      }
 
-async function latestRelease(){
-  const tracks = await searchTracks('Mr.FLEN');
-  return tracks[0] ? normalizeAudiusTrack(tracks[0]) : null;
+      async function trendingTracks(genre) {
+        const host = await pickHost();
+        const genreParam = genre ? `&genre=${encodeURIComponent(genre)}` : "";
+        const url = `${host}/v1/tracks/trending?limit=5${genreParam}&app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
+        const res = await fetch(url, {
+          headers: { Accept: "application/json" },
+        });
+        const json = await res.json();
+        return (json.data || []).map(normalizeAudiusTrack);
+      }
 
-async function fetchPlaylist(id){
-  const host = await pickHost();
-  const url = `${host}/v1/playlists/${id}?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
-  const res = await fetch(url, { headers: { Accept:'application/json' } });
-  const json = await res.json();
-  return json.data || null;
-}
+      async function trendingPlaylists() {
+        const host = await pickHost();
+        const url = `${host}/v1/playlists/trending?limit=5&app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
+        const res = await fetch(url, {
+          headers: { Accept: "application/json" },
+        });
+        const json = await res.json();
+        return json.data || [];
+      }
 
-}
+      async function latestRelease() {
+        const tracks = await searchTracks("Mr.FLEN");
+        return tracks[0] ? normalizeAudiusTrack(tracks[0]) : null;
 
-function renderFeatured(track){
-  if(!track) return '';
-  return `
+        async function fetchPlaylist(id) {
+          const host = await pickHost();
+          const url = `${host}/v1/playlists/${id}?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
+          const res = await fetch(url, {
+            headers: { Accept: "application/json" },
+          });
+          const json = await res.json();
+          return json.data || null;
+        }
+      }
+
+      function renderFeatured(track) {
+        if (!track) return "";
+        return `
     <a href="track.html?platform=${track.platform}&id=${track.id}" class="glass featured" style="display:block;text-decoration:none;color:inherit">
       <img src="${track.artwork}" alt="artwork" />
       <div style="padding:16px">
-        <div style="font-weight:700">${track.title || ''}</div>
+        <div style="font-weight:700">${track.title || ""}</div>
         <div style="opacity:.7">@${track.user.handle}</div>
       </div>
     </a>`;
-}
+      }
 
-function normalizeAudiusTrack(t){
-  return {
-    platform:'audius',
-    id:t.id,
-    title:t.title,
-    artwork:(t.artwork && (t.artwork['150x150'] || t.artwork['480x480'])) || '',
-    user:{ handle: t.user && t.user.handle ? t.user.handle : '' }
-  };
-}
+      function normalizeAudiusTrack(t) {
+        return {
+          platform: "audius",
+          id: t.id,
+          title: t.title,
+          artwork:
+            (t.artwork && (t.artwork["150x150"] || t.artwork["480x480"])) || "",
+          user: { handle: t.user && t.user.handle ? t.user.handle : "" },
+        };
+      }
 
-function normalizeSoundCloudTrack(t){
-  return {
-    platform:'soundcloud',
-    id:t.id,
-    title:t.title,
-    artwork:t.artwork_url || '',
-    permalink_url:t.permalink_url,
-    user:{ handle: t.user && t.user.username ? t.user.username : '' }
-  };
-}
+      function normalizeSoundCloudTrack(t) {
+        return {
+          platform: "soundcloud",
+          id: t.id,
+          title: t.title,
+          artwork: t.artwork_url || "",
+          permalink_url: t.permalink_url,
+          user: { handle: t.user && t.user.username ? t.user.username : "" },
+        };
+      }
 
-/** UI wiring **/
+      /** UI wiring **/
 
-const results = document.querySelector('#results');
-let audioPlayer = document.querySelector('#player');
-const search  = document.querySelector('#search');
-const login   = document.querySelector('#login');
-const nextBtn = document.querySelector('#next');
-const queueLabel = document.querySelector('#queueLabel');
-const genresEl = document.querySelector('#genres');
-const GENRES = ['All','UKG','Grime','House','DNB'];
-let currentGenre = null;
-GENRES.forEach(g=>{
-  const chip = document.createElement('button');
-  chip.textContent = g;
-  chip.className = 'chip' + (g==='All' ? ' active' : '');
-  chip.onclick = () => {
-    currentGenre = g==='All' ? null : g;
-    Array.from(genresEl.children).forEach(c=>c.classList.remove('active'));
-    chip.classList.add('active');
-    loadHome(currentGenre);
-  };
-  genresEl.appendChild(chip);
-});
+      const results = document.querySelector("#results");
+      let audioPlayer = document.querySelector("#player");
+      const search = document.querySelector("#search");
+      const login = document.querySelector("#login");
+      const nextBtn = document.querySelector("#next");
+      const shuffleBtn = document.querySelector("#shuffle");
+      const queueLabel = document.querySelector("#queueLabel");
+      const genresEl = document.querySelector("#genres");
+      const GENRES = ["All", "UKG", "Grime", "House", "DNB"];
+      let currentGenre = null;
+      GENRES.forEach((g) => {
+        const chip = document.createElement("button");
+        chip.textContent = g;
+        chip.className = "chip" + (g === "All" ? " active" : "");
+        chip.onclick = () => {
+          currentGenre = g === "All" ? null : g;
+          Array.from(genresEl.children).forEach((c) =>
+            c.classList.remove("active"),
+          );
+          chip.classList.add("active");
+          loadHome(currentGenre);
+        };
+        genresEl.appendChild(chip);
+      });
 
-const trackCache = {};
-const queue = [];
-let currentIndex = -1;
+      const trackCache = {};
+      const queue = [];
+      let currentIndex = -1;
 
-function updateQueue(){ queueLabel.textContent = `Queue: ${queue.length}`; }
+      function updateQueue() {
+        queueLabel.textContent = `Queue: ${queue.length}`;
+      }
 
-async function playTrack(track){
-  const container = document.querySelector('#playerContainer');
-  if(track.platform==='soundcloud'){
-    const res = await fetch(`https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(track.permalink_url)}`);
-    const { html } = await res.json();
-    container.innerHTML = html;
-    audioPlayer = null;
-  }else{
-    container.innerHTML = '<audio id="player" controls preload="none" style="width:100%"></audio>';
-    audioPlayer = document.querySelector('#player');
-    const url = await streamUrl(track.id);
-    audioPlayer.src = url;
-    await audioPlayer.play();
-    audioPlayer.addEventListener('ended', ()=> nextBtn.onclick(), { once:true });
-  }
-}
+      async function playTrack(track) {
+        const container = document.querySelector("#playerContainer");
+        if (track.platform === "soundcloud") {
+          const res = await fetch(
+            `https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(track.permalink_url)}`,
+          );
+          const { html } = await res.json();
+          container.innerHTML = html;
+          audioPlayer = null;
+        } else {
+          container.innerHTML =
+            '<audio id="player" controls preload="none" style="width:100%"></audio>';
+          audioPlayer = document.querySelector("#player");
+          const url = await streamUrl(track.id);
+          audioPlayer.src = url;
+          await audioPlayer.play();
+          audioPlayer.addEventListener("ended", () => nextBtn.onclick(), {
+            once: true,
+          });
+        }
+      }
 
-function renderTracksList(list, includeLink=false){
-  return list.map(t=>{
-    trackCache[`${t.platform}:${t.id}`]=t;
-    const buttons = [`<button data-platform="${t.platform}" data-id="${t.id}" class="btn play">▶</button>`];
-    if(t.platform==='audius') buttons.push(`<button data-platform="${t.platform}" data-id="${t.id}" class="btn queue">➕</button>`);
-    if(includeLink) buttons.push(`<a href="track.html?platform=${t.platform}&id=${t.id}" class="btn">Go To Track</a>`);
-    const cols = `72px 1fr${' auto'.repeat(buttons.length)}`;
-    const badge = `<span class="pill">${t.platform==='audius'?'Audius':'SoundCloud'}</span>`;
-    return `
+      function renderTracksList(list, includeLink = false) {
+        return list
+          .map((t) => {
+            trackCache[`${t.platform}:${t.id}`] = t;
+            const buttons = [
+              `<button data-platform="${t.platform}" data-id="${t.id}" class="btn play">▶</button>`,
+            ];
+            if (t.platform === "audius")
+              buttons.push(
+                `<button data-platform="${t.platform}" data-id="${t.id}" class="btn queue">➕</button>`,
+              );
+            if (includeLink)
+              buttons.push(
+                `<a href="track.html?platform=${t.platform}&id=${t.id}" class="btn">Go To Track</a>`,
+              );
+            const cols = `72px 1fr${" auto".repeat(buttons.length)}`;
+            const badge = `<span class="pill">${t.platform === "audius" ? "Audius" : "SoundCloud"}</span>`;
+            return `
       <div class="glass track-card" style="grid-template-columns:${cols};">
         <img src="${t.artwork}" width="72" height="72" loading="lazy" alt="artwork" />
         <div>
-          <div style="font-weight:700">${t.title || ''}</div>
+          <div style="font-weight:700">${t.title || ""}</div>
           <div style="opacity:.7">@${t.user.handle} ${badge}</div>
         </div>
-        ${buttons.join('')}
+        ${buttons.join("")}
       </div>`;
-  }).join('');
-}
-
-function attachTrackEvents(container=results){
-  container.querySelectorAll('.play').forEach(btn=>{
-    btn.onclick = async () => {
-      const key = `${btn.dataset.platform}:${btn.dataset.id}`;
-      const track = trackCache[key];
-      if(track.platform==='audius'){
-        queue.push(track);
-        currentIndex = queue.length - 1;
-        updateQueue();
+          })
+          .join("");
       }
-      await playTrack(track);
-    };
-  });
-  container.querySelectorAll('.queue').forEach(btn=>{
-    btn.onclick = () => {
-      const key = `${btn.dataset.platform}:${btn.dataset.id}`;
-      const track = trackCache[key];
-      queue.push(track);
-      updateQueue();
-    };
-  });
-}
 
-function renderPlaylistList(list){
-  return list.map(p=>{
-    const art = (p.artwork && (p.artwork['150x150'] || p.artwork['480x480'])) || '';
-    return `
+      function attachTrackEvents(container = results) {
+        container.querySelectorAll(".play").forEach((btn) => {
+          btn.onclick = async () => {
+            const key = `${btn.dataset.platform}:${btn.dataset.id}`;
+            const track = trackCache[key];
+            if (track.platform === "audius") {
+              queue.push(track);
+              currentIndex = queue.length - 1;
+              updateQueue();
+            }
+            await playTrack(track);
+          };
+        });
+        container.querySelectorAll(".queue").forEach((btn) => {
+          btn.onclick = () => {
+            const key = `${btn.dataset.platform}:${btn.dataset.id}`;
+            const track = trackCache[key];
+            queue.push(track);
+            updateQueue();
+          };
+        });
+      }
+
+      function renderPlaylistList(list) {
+        return list
+          .map((p) => {
+            const art =
+              (p.artwork && (p.artwork["150x150"] || p.artwork["480x480"])) ||
+              "";
+            return `
       <a class="glass playlist-card" href="playlist.html?id=${p.id}">
         <img src="${art}" width="72" height="72" loading="lazy" alt="artwork" />
         <div>
-          <div style="font-weight:700">${p.playlist_name || ''}</div>
+          <div style="font-weight:700">${p.playlist_name || ""}</div>
           <div style="opacity:.7">${p.track_count || 0} tracks</div>
         </div>
       </a>`;
-  }).join('');
-}
+          })
+          .join("");
+      }
 
-async function loadHome(genre){
-  results.innerHTML = '<div class="glass" style="padding:16px;">Loading…</div>';
-  try{
-    const [tracks, playlists, feature] = await Promise.all([
-      trendingTracks(genre),
-      trendingPlaylists(),
-      latestRelease()
-    ]);
-    const genreLabel = genre ? ` — ${genre}` : '';
-    results.innerHTML = `
+      async function loadHome(genre) {
+        results.innerHTML =
+          '<div class="glass" style="padding:16px;">Loading…</div>';
+        try {
+          const [tracks, playlists, feature] = await Promise.all([
+            trendingTracks(genre),
+            trendingPlaylists(),
+            latestRelease(),
+          ]);
+          const genreLabel = genre ? ` — ${genre}` : "";
+          results.innerHTML = `
       ${renderFeatured(feature)}
       <h2>Trending Tracks${genreLabel}</h2>
-      <div class="carousel">${renderTracksList(tracks,true)}</div>
+      <div class="carousel">${renderTracksList(tracks, true)}</div>
       <h2>Trending Playlists</h2>
       ${renderPlaylistList(playlists)}
     `;
-    attachTrackEvents();
-  }catch(err){
-    console.error(err);
-    results.innerHTML = '<div class="glass" style="padding:16px;">Error loading trending data.</div>';
-  }
-}
-
-let debounceTimer = null;
-search.addEventListener('input', async (e)=>{
-  const q = e.target.value.trim();
-  if (debounceTimer) clearTimeout(debounceTimer);
-  debounceTimer = setTimeout(async () => {
-    if (!q){ loadHome(currentGenre); return; }
-    results.innerHTML = '<div class="glass" style="padding:16px;">Searching…</div>';
-    try{
-      let scError = false;
-      const [a, s] = await Promise.all([
-        searchTracks(q),
-        searchSoundCloud(q).catch(()=>{ scError = true; return []; })
-      ]);
-      const tracks = [
-        ...a.filter(t=>t.user && t.user.handle === MRFLEN_HANDLE).map(normalizeAudiusTrack),
-        ...s.map(normalizeSoundCloudTrack)
-      ];
-      if(!tracks.length){
-        results.innerHTML = '<div class="glass" style="padding:16px;">No Mr.FLEN tracks found.</div>';
-        if(scError) results.innerHTML += '<div class="glass" style="padding:16px;margin-top:8px;">⚠️ SoundCloud results unavailable.</div>';
-        return;
+          attachTrackEvents();
+        } catch (err) {
+          console.error(err);
+          results.innerHTML =
+            '<div class="glass" style="padding:16px;">Error loading trending data.</div>';
+        }
       }
-      tracks.sort((a,b)=>a.title.localeCompare(b.title));
-      let html = renderTracksList(tracks, true);
-      if(scError) html = '<div class="glass" style="padding:16px;">⚠️ SoundCloud results unavailable.</div>' + html;
-      results.innerHTML = html;
-      attachTrackEvents();
-    }catch(err){
-      console.error(err);
-      results.innerHTML = '<div class="glass" style="padding:16px;">Error contacting APIs.</div>';
-    }
-  }, 250);
-});
 
-nextBtn.onclick = () => {
-  if (currentIndex + 1 < queue.length){
-    currentIndex++;
-    playTrack(queue[currentIndex]);
-  }
-};
+      let debounceTimer = null;
+      search.addEventListener("input", async (e) => {
+        const q = e.target.value.trim();
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(async () => {
+          if (!q) {
+            loadHome(currentGenre);
+            return;
+          }
+          results.innerHTML =
+            '<div class="glass" style="padding:16px;">Searching…</div>';
+          try {
+            let scError = false;
+            const [a, s] = await Promise.all([
+              searchTracks(q),
+              searchSoundCloud(q).catch(() => {
+                scError = true;
+                return [];
+              }),
+            ]);
+            const tracks = [
+              ...a
+                .filter((t) => t.user && t.user.handle === MRFLEN_HANDLE)
+                .map(normalizeAudiusTrack),
+              ...s.map(normalizeSoundCloudTrack),
+            ];
+            if (!tracks.length) {
+              results.innerHTML =
+                '<div class="glass" style="padding:16px;">No Mr.FLEN tracks found.</div>';
+              if (scError)
+                results.innerHTML +=
+                  '<div class="glass" style="padding:16px;margin-top:8px;">⚠️ SoundCloud results unavailable.</div>';
+              return;
+            }
+            tracks.sort((a, b) => a.title.localeCompare(b.title));
+            let html = renderTracksList(tracks, true);
+            if (scError)
+              html =
+                '<div class="glass" style="padding:16px;">⚠️ SoundCloud results unavailable.</div>' +
+                html;
+            results.innerHTML = html;
+            attachTrackEvents();
+          } catch (err) {
+            console.error(err);
+            results.innerHTML =
+              '<div class="glass" style="padding:16px;">Error contacting APIs.</div>';
+          }
+        }, 250);
+      });
 
-login.onclick = () => alert('OAuth login coming soon');
+      nextBtn.onclick = () => {
+        if (currentIndex + 1 < queue.length) {
+          currentIndex++;
+          playTrack(queue[currentIndex]);
+        }
+      };
 
-loadHome(currentGenre);
+      login.onclick = () => alert("OAuth login coming soon");
 
-// ⌘/Ctrl-K to focus
-document.addEventListener('keydown', (e)=>{
-  if ((e.ctrlKey||e.metaKey) && e.key.toLowerCase()==='k'){ e.preventDefault(); search.focus(); }
-});
-</script>
-</body>
+      loadHome(currentGenre);
+
+      // ⌘/Ctrl-K to focus
+      document.addEventListener("keydown", (e) => {
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
+          e.preventDefault();
+          search.focus();
+        }
+      });
+      shuffleBtn.onclick = () => {
+        if (queue.length) {
+          currentIndex = Math.floor(Math.random() * queue.length);
+          playTrack(queue[currentIndex]);
+        }
+      };
+    </script>
+  </body>
 </html>

--- a/playlist.html
+++ b/playlist.html
@@ -1,139 +1,200 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Playlist - Mr.FLENs Music Finder</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet" />
-  <style>
-    :root{
-      --color-primary:#5CF3FF;
-      --color-secondary:#9B5CFF;
-      --color-bg:#05060A;
-      --color-glass:rgba(255,255,255,0.06);
-      --color-text:#EAF4FF;
-      --color-muted:#8A96B3;
-    }
-    body{
-      background:var(--color-bg);
-      color:var(--color-text);
-      font-family:'Inter',system-ui,sans-serif;
-      margin:0;
-    }
-    .glass{
-      backdrop-filter:saturate(1.4) blur(12px);
-      background:var(--color-glass);
-      border:1px solid #ffffff11;
-      border-radius:16px;
-    }
-    .track-card{
-      display:grid;
-      grid-template-columns:72px 1fr auto auto;
-      gap:12px;
-      padding:12px;
-      align-items:center;
-    }
-    .track-card img{border-radius:10px}
-    .btn{
-      display:inline-block;
-      text-decoration:none;
-      border:1px solid var(--color-primary);
-      color:var(--color-primary);
-      padding:8px 12px;
-      border-radius:10px;
-      background:transparent;
-      cursor:pointer;
-    }
-    .btn:hover{background:var(--color-secondary);color:#05060A}
-    .pill{
-      padding:2px 8px;
-      border:1px solid #ffffff22;
-      border-radius:999px;
-      font-size:12px;
-      opacity:.8;
-    }
-  </style>
-</head>
-<body>
-  <header class="glass" style="padding:12px 16px;margin:16px;">
-    <a href="index.html" class="pill" style="text-decoration:none;color:inherit">← Home</a>
-  </header>
-  <main id="playlist" class="glass" style="padding:16px;margin:16px;">Loading playlist…</main>
-  <footer class="glass" style="position:fixed;left:0;right:0;bottom:0;padding:8px;margin:16px;">
-    <audio id="player" controls preload="none" style="width:100%"></audio>
-  </footer>
-  <script type="module">
-  const AUDIUS_APP_NAME = "Mr.FLENs Music Finder";
-  const AUDIUS_API_KEY  = "922e6edcae9856000bf6814a1ee5745bfb57734";
-  async function pickHost(){
-    const res = await fetch('https://api.audius.co');
-    const { data } = await res.json();
-    return data[Math.floor(Math.random()*data.length)];
-  }
-  async function streamUrl(trackId){
-    const host = await pickHost();
-    return `${host}/v1/tracks/${trackId}/stream?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
-  }
-  async function fetchPlaylist(id){
-    const host = await pickHost();
-    const url = `${host}/v1/playlists/${id}?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
-    const res = await fetch(url, { headers: { Accept:'application/json' } });
-    const json = await res.json();
-    return json.data || null;
-  }
-  function renderTracksList(list){
-    return list.map(t=>{
-      trackCache[t.id]=t;
-      const art = (t.artwork && (t.artwork['150x150'] || t.artwork['480x480'])) || '';
-      const handle = t.user && t.user.handle ? t.user.handle : '';
-      return `
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Playlist - Mr.FLENs Music Finder</title>
+    <link
+      rel="icon"
+      href="https://audius-content-6.cultur3stake.com/content/01K0PYMD8X6ZA6JNCDWMWD4510/480x480.jpg"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-primary: #c97c1a;
+        --color-secondary: #8b5e2e;
+        --color-bg: #1a0f0a;
+        --color-glass: rgba(80, 56, 40, 0.6);
+        --color-text: #f5e6c4;
+        --color-muted: #b2947d;
+      }
+      body {
+        background: var(--color-bg);
+        color: var(--color-text);
+        font-family: "Cinzel", serif;
+        margin: 0;
+      }
+      .glass {
+        backdrop-filter: saturate(1.2) blur(10px);
+        background: var(--color-glass);
+        border: 1px solid var(--color-secondary);
+        border-radius: 16px;
+        box-shadow: 0 0 10px #000;
+      }
+      .track-card {
+        display: grid;
+        grid-template-columns: 72px 1fr auto auto;
+        gap: 12px;
+        padding: 12px;
+        align-items: center;
+      }
+      .track-card img {
+        border-radius: 10px;
+      }
+      .btn {
+        display: inline-block;
+        text-decoration: none;
+        border: 1px solid var(--color-primary);
+        color: var(--color-bg);
+        padding: 8px 12px;
+        border-radius: 10px;
+        background: var(--color-primary);
+        cursor: pointer;
+      }
+      .btn:hover {
+        background: var(--color-secondary);
+        color: var(--color-text);
+      }
+      .pill {
+        padding: 2px 8px;
+        border: 1px solid var(--color-secondary);
+        border-radius: 999px;
+        font-size: 12px;
+        background: var(--color-glass);
+      }
+      .logo {
+        height: 40px;
+        width: 40px;
+        border-radius: 50%;
+        border: 2px solid var(--color-secondary);
+        box-shadow: 0 0 4px #000;
+      }
+    </style>
+  </head>
+  <body>
+    <header
+      class="glass"
+      style="
+        padding: 12px 16px;
+        margin: 16px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      "
+    >
+      <img
+        src="https://audius-content-6.cultur3stake.com/content/01K0PYMD8X6ZA6JNCDWMWD4510/480x480.jpg"
+        alt="Mr.FLEN logo"
+        class="logo"
+      />
+      <a
+        href="index.html"
+        class="pill"
+        style="text-decoration: none; color: inherit"
+        >← Home</a
+      >
+    </header>
+    <main id="playlist" class="glass" style="padding: 16px; margin: 16px">
+      Loading playlist…
+    </main>
+    <footer
+      class="glass"
+      style="
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        padding: 8px;
+        margin: 16px;
+      "
+    >
+      <audio id="player" controls preload="none" style="width: 100%"></audio>
+    </footer>
+    <script type="module">
+      const AUDIUS_APP_NAME = "Mr.FLENs Music Finder";
+      const AUDIUS_API_KEY = "922e6edcae9856000bf6814a1ee5745bfb57734";
+      async function pickHost() {
+        const res = await fetch("https://api.audius.co");
+        const { data } = await res.json();
+        return data[Math.floor(Math.random() * data.length)];
+      }
+      async function streamUrl(trackId) {
+        const host = await pickHost();
+        return `${host}/v1/tracks/${trackId}/stream?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
+      }
+      async function fetchPlaylist(id) {
+        const host = await pickHost();
+        const url = `${host}/v1/playlists/${id}?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
+        const res = await fetch(url, {
+          headers: { Accept: "application/json" },
+        });
+        const json = await res.json();
+        return json.data || null;
+      }
+      function renderTracksList(list) {
+        return list
+          .map((t) => {
+            trackCache[t.id] = t;
+            const art =
+              (t.artwork && (t.artwork["150x150"] || t.artwork["480x480"])) ||
+              "";
+            const handle = t.user && t.user.handle ? t.user.handle : "";
+            return `
         <div class="glass track-card">
           <img src="${art}" width="72" height="72" loading="lazy" alt="artwork" />
           <div>
-            <div style="font-weight:700">${t.title || ''}</div>
+            <div style="font-weight:700">${t.title || ""}</div>
             <div style="opacity:.7">@${handle}</div>
           </div>
           <button data-id="${t.id}" class="btn play">▶</button>
           <a href="track.html?platform=audius&id=${t.id}" class="btn">Go To Track</a>
         </div>`;
-    }).join('');
-  }
-  function attachTrackEvents(){
-    document.querySelectorAll('.play').forEach(btn=>{
-      btn.onclick = async () => {
-        const track = trackCache[btn.dataset.id];
-        player.src = await streamUrl(track.id);
-        await player.play();
-      };
-    });
-  }
-  const trackCache = {};
-  const el = document.querySelector('#playlist');
-  const player = document.querySelector('#player');
-  const params = new URLSearchParams(window.location.search);
-  const id = params.get('id');
-  if(id){
-    try{
-      const pl = await fetchPlaylist(id);
-      if(!pl){ el.textContent = 'Playlist not found.'; }
-      else {
-        const art = (pl.artwork && (pl.artwork['480x480'] || pl.artwork['150x150'])) || '';
-        el.innerHTML = `
+          })
+          .join("");
+      }
+      function attachTrackEvents() {
+        document.querySelectorAll(".play").forEach((btn) => {
+          btn.onclick = async () => {
+            const track = trackCache[btn.dataset.id];
+            player.src = await streamUrl(track.id);
+            await player.play();
+          };
+        });
+      }
+      const trackCache = {};
+      const el = document.querySelector("#playlist");
+      const player = document.querySelector("#player");
+      const params = new URLSearchParams(window.location.search);
+      const id = params.get("id");
+      if (id) {
+        try {
+          const pl = await fetchPlaylist(id);
+          if (!pl) {
+            el.textContent = "Playlist not found.";
+          } else {
+            const art =
+              (pl.artwork &&
+                (pl.artwork["480x480"] || pl.artwork["150x150"])) ||
+              "";
+            el.innerHTML = `
           <img src="${art}" alt="artwork" style="width:200px;height:200px;border-radius:12px" />
-          <h1>${pl.playlist_name || ''}</h1>
+          <h1>${pl.playlist_name || ""}</h1>
           <p>${pl.track_count || 0} tracks</p>
           ${renderTracksList(pl.tracks || [])}`;
-        attachTrackEvents();
+            attachTrackEvents();
+          }
+        } catch (err) {
+          console.error(err);
+          el.textContent = "Error loading playlist.";
+        }
+      } else {
+        el.textContent = "No playlist id provided.";
       }
-    }catch(err){
-      console.error(err);
-      el.textContent = 'Error loading playlist.';
-    }
-  }else{
-    el.textContent = 'No playlist id provided.';
-  }
-  </script>
-</body>
+    </script>
+  </body>
 </html>

--- a/track.html
+++ b/track.html
@@ -1,106 +1,166 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Track Details - Mr.FLENs Music Finder</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet" />
-  <style>
-    :root{
-      --color-primary:#5CF3FF;
-      --color-secondary:#9B5CFF;
-      --color-bg:#05060A;
-      --color-glass:rgba(255,255,255,0.06);
-      --color-text:#EAF4FF;
-      --color-muted:#8A96B3;
-    }
-    body{
-      background:var(--color-bg);
-      color:var(--color-text);
-      font-family:'Inter',system-ui,sans-serif;
-      margin:0;
-    }
-    .glass{
-      backdrop-filter:saturate(1.4) blur(12px);
-      background:var(--color-glass);
-      border:1px solid #ffffff11;
-      border-radius:16px;
-    }
-  </style>
-</head>
-<body>
-  <header class="glass" style="padding:12px 16px;margin:16px;">
-    <a href="index.html" class="pill" style="text-decoration:none;color:inherit">← Home</a>
-  </header>
-  <main id="track" class="glass" style="padding:16px;margin:16px;">Loading track…</main>
-  <footer class="glass" style="position:fixed;left:0;right:0;bottom:0;padding:8px;margin:16px;">
-    <audio id="player" controls preload="none" style="width:100%"></audio>
-  </footer>
-  <script type="module">
-  const AUDIUS_APP_NAME = "Mr.FLENs Music Finder";
-  const AUDIUS_API_KEY  = "922e6edcae9856000bf6814a1ee5745bfb57734";
-  const SOUNDCLOUD_CLIENT_ID = 'YOUR_SOUNDCLOUD_API_KEY';
-  async function pickHost(){
-    const res = await fetch('https://api.audius.co');
-    const { data } = await res.json();
-    return data[Math.floor(Math.random()*data.length)];
-  }
-  async function streamUrl(trackId){
-    const host = await pickHost();
-    return `${host}/v1/tracks/${trackId}/stream?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
-  }
-  async function fetchAudiusTrack(id){
-    const host = await pickHost();
-    const url = `${host}/v1/tracks/${id}?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
-    const res = await fetch(url, { headers: { Accept:'application/json' } });
-    const json = await res.json();
-    return json.data || null;
-  }
-  async function fetchSoundCloudTrack(id){
-    const url = `https://api.soundcloud.com/tracks/${id}?client_id=${SOUNDCLOUD_CLIENT_ID}`;
-    const res = await fetch(url);
-    if(!res.ok) throw new Error('sc');
-    return await res.json();
-  }
-  const el = document.querySelector('#track');
-  const playerContainer = document.querySelector('#player');
-  const params = new URLSearchParams(window.location.search);
-  const id = params.get('id');
-  const platform = params.get('platform') || 'audius';
-  if(id){
-    try{
-      if(platform==='soundcloud'){
-        const t = await fetchSoundCloudTrack(id);
-        const art = t.artwork_url || '';
-        el.innerHTML = `
-          <img src="${art}" alt="artwork" style="width:200px;height:200px;border-radius:12px" />
-          <h1>${t.title || ''}</h1>
-          <p>@${t.user ? t.user.username : ''}</p>`;
-        const o = await fetch(`https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(t.permalink_url)}`);
-        const { html } = await o.json();
-        playerContainer.outerHTML = html;
-      }else{
-        const t = await fetchAudiusTrack(id);
-        if(!t){ el.textContent = 'Track not found.'; }
-        else {
-          const art = (t.artwork && (t.artwork['480x480'] || t.artwork['150x150'])) || '';
-          const handle = t.user && t.user.handle ? t.user.handle : '';
-          el.innerHTML = `
-            <img src="${art}" alt="artwork" style="width:200px;height:200px;border-radius:12px" />
-            <h1>${t.title || ''}</h1>
-            <p>@${handle}</p>`;
-          playerContainer.src = await streamUrl(t.id);
-        }
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Track Details - Mr.FLENs Music Finder</title>
+    <link
+      rel="icon"
+      href="https://audius-content-6.cultur3stake.com/content/01K0PYMD8X6ZA6JNCDWMWD4510/480x480.jpg"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --color-primary: #c97c1a;
+        --color-secondary: #8b5e2e;
+        --color-bg: #1a0f0a;
+        --color-glass: rgba(80, 56, 40, 0.6);
+        --color-text: #f5e6c4;
+        --color-muted: #b2947d;
       }
-    }catch(err){
-      console.error(err);
-      el.textContent = 'Error loading track.';
-    }
-  }else{
-    el.textContent = 'No track id provided.';
-  }
-  </script>
-</body>
+      body {
+        background: var(--color-bg);
+        color: var(--color-text);
+        font-family: "Cinzel", serif;
+        margin: 0;
+      }
+      .glass {
+        backdrop-filter: saturate(1.2) blur(10px);
+        background: var(--color-glass);
+        border: 1px solid var(--color-secondary);
+        border-radius: 16px;
+        box-shadow: 0 0 10px #000;
+      }
+      .pill {
+        padding: 2px 8px;
+        border: 1px solid var(--color-secondary);
+        border-radius: 999px;
+        font-size: 12px;
+        background: var(--color-glass);
+      }
+      .logo {
+        height: 40px;
+        width: 40px;
+        border-radius: 50%;
+        border: 2px solid var(--color-secondary);
+        box-shadow: 0 0 4px #000;
+      }
+    </style>
+  </head>
+  <body>
+    <header
+      class="glass"
+      style="
+        padding: 12px 16px;
+        margin: 16px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      "
+    >
+      <img
+        src="https://audius-content-6.cultur3stake.com/content/01K0PYMD8X6ZA6JNCDWMWD4510/480x480.jpg"
+        alt="Mr.FLEN logo"
+        class="logo"
+      />
+      <a
+        href="index.html"
+        class="pill"
+        style="text-decoration: none; color: inherit"
+        >← Home</a
+      >
+    </header>
+    <main id="track" class="glass" style="padding: 16px; margin: 16px">
+      Loading track…
+    </main>
+    <footer
+      class="glass"
+      style="
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        padding: 8px;
+        margin: 16px;
+      "
+    >
+      <audio id="player" controls preload="none" style="width: 100%"></audio>
+    </footer>
+    <script type="module">
+      const AUDIUS_APP_NAME = "Mr.FLENs Music Finder";
+      const AUDIUS_API_KEY = "922e6edcae9856000bf6814a1ee5745bfb57734";
+      const SOUNDCLOUD_CLIENT_ID = "YOUR_SOUNDCLOUD_API_KEY";
+      async function pickHost() {
+        const res = await fetch("https://api.audius.co");
+        const { data } = await res.json();
+        return data[Math.floor(Math.random() * data.length)];
+      }
+      async function streamUrl(trackId) {
+        const host = await pickHost();
+        return `${host}/v1/tracks/${trackId}/stream?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
+      }
+      async function fetchAudiusTrack(id) {
+        const host = await pickHost();
+        const url = `${host}/v1/tracks/${id}?app_name=${encodeURIComponent(AUDIUS_APP_NAME)}&api_key=${encodeURIComponent(AUDIUS_API_KEY)}`;
+        const res = await fetch(url, {
+          headers: { Accept: "application/json" },
+        });
+        const json = await res.json();
+        return json.data || null;
+      }
+      async function fetchSoundCloudTrack(id) {
+        const url = `https://api.soundcloud.com/tracks/${id}?client_id=${SOUNDCLOUD_CLIENT_ID}`;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error("sc");
+        return await res.json();
+      }
+      const el = document.querySelector("#track");
+      const playerContainer = document.querySelector("#player");
+      const params = new URLSearchParams(window.location.search);
+      const id = params.get("id");
+      const platform = params.get("platform") || "audius";
+      if (id) {
+        try {
+          if (platform === "soundcloud") {
+            const t = await fetchSoundCloudTrack(id);
+            const art = t.artwork_url || "";
+            el.innerHTML = `
+          <img src="${art}" alt="artwork" style="width:200px;height:200px;border-radius:12px" />
+          <h1>${t.title || ""}</h1>
+          <p>@${t.user ? t.user.username : ""}</p>`;
+            const o = await fetch(
+              `https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(t.permalink_url)}`,
+            );
+            const { html } = await o.json();
+            playerContainer.outerHTML = html;
+          } else {
+            const t = await fetchAudiusTrack(id);
+            if (!t) {
+              el.textContent = "Track not found.";
+            } else {
+              const art =
+                (t.artwork && (t.artwork["480x480"] || t.artwork["150x150"])) ||
+                "";
+              const handle = t.user && t.user.handle ? t.user.handle : "";
+              el.innerHTML = `
+            <img src="${art}" alt="artwork" style="width:200px;height:200px;border-radius:12px" />
+            <h1>${t.title || ""}</h1>
+            <p>@${handle}</p>`;
+              playerContainer.src = await streamUrl(t.id);
+            }
+          }
+        } catch (err) {
+          console.error(err);
+          el.textContent = "Error loading track.";
+        }
+      } else {
+        el.textContent = "No track id provided.";
+      }
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle pages with a steampunk inspired palette, fonts, and favicon
- add site logo and shuffle playback control for richer UI

## Testing
- `npx prettier --check index.html playlist.html track.html`


------
https://chatgpt.com/codex/tasks/task_e_68b6d5617d908333a26f8d45a6cba448