### PR TITLE
feat: apply dark dashboard styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A single-file web app that searches and plays tracks from **Audius**. Built as a lightweight, futuristic library for **Mr.FLEN**.
 
+The interface now follows a dark, glassy dashboard style similar to the provided mock‑up reference.
+
 ## User interface
 
 The app ships as plain HTML files. Open `index.html` in a browser to explore the UI.

--- a/index.html
+++ b/index.html
@@ -10,23 +10,24 @@
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Inter:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Inter:wght@400;500;700&display=swap"
+        rel="stylesheet"
+      />
     <style>
       :root {
-        --color-primary: #c97c1a;
-        --color-secondary: #8b5e2e;
-        --color-bg: #1a0f0a;
-        --color-glass: rgba(80, 56, 40, 0.6);
-        --color-text: #f5e6c4;
-        --color-muted: #b2947d;
+        /* Dark, futuristic palette inspired by the new dashboard mockup */
+        --color-primary: #2f81f7;
+        --color-secondary: #1f6feb;
+        --color-bg: #0d1117;
+        --color-glass: rgba(32, 38, 50, 0.6);
+        --color-text: #f0f6fc;
+        --color-muted: #8b949e;
       }
       body {
         background: var(--color-bg);
         color: var(--color-text);
-        font-family: "Cinzel", serif;
+        font-family: "Inter", sans-serif;
         margin: 0;
       }
       header,
@@ -36,11 +37,11 @@
         margin: auto;
       }
       .glass {
-        backdrop-filter: saturate(1.2) blur(10px);
+        backdrop-filter: saturate(1.2) blur(12px);
         background: var(--color-glass);
-        border: 1px solid var(--color-secondary);
+        border: 1px solid #ffffff11;
         border-radius: 16px;
-        box-shadow: 0 0 10px #000;
+        box-shadow: 0 0 20px #000;
       }
       .grid {
         display: grid;
@@ -51,7 +52,7 @@
         padding: 12px 14px;
         border-radius: 12px;
         border: 1px solid #ffffff22;
-        background: #0b1020;
+        background: #1c2333;
         color: var(--color-text);
         outline: none;
       }
@@ -76,7 +77,7 @@
         display: inline-block;
         text-decoration: none;
         border: 1px solid var(--color-primary);
-        color: var(--color-bg);
+        color: var(--color-text);
         padding: 8px 12px;
         border-radius: 10px;
         background: var(--color-primary);
@@ -84,7 +85,7 @@
       }
       .btn:hover {
         background: var(--color-secondary);
-        color: var(--color-text);
+        border-color: var(--color-secondary);
       }
       .playlist-card {
         display: grid;
@@ -101,7 +102,7 @@
       }
       .pill {
         padding: 2px 8px;
-        border: 1px solid var(--color-secondary);
+        border: 1px solid #ffffff22;
         border-radius: 999px;
         font-size: 12px;
         background: var(--color-glass);


### PR DESCRIPTION
## Summary
- restyle app with dark, glassy palette inspired by new dashboard mockup
- note new styling approach in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d6db4ca48333baacd700020ceb07