### PR TITLE
feat: add social login modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The interface now follows a dark, glassy dashboard style similar to the provided
 
 The app ships as plain HTML files. Open `index.html` in a browser to explore the UI.
 
-- **Header** – brand title with a login placeholder and global search bar (press `Ctrl/⌘+K`).
+- **Header** – brand title with a social login modal (Google/Facebook/Instagram) and global search bar (press `Ctrl/⌘+K`).
 - **Genre chips** – quickly filter trending tracks by UKG, Grime, House, or DNB.
 - **Trending carousel & featured banner** – showcase the latest release and popular tracks.
 - **Track cards** – hover to reveal play controls and a **Go To Track** button that links to `track.html`.
@@ -19,9 +19,9 @@ The app ships as plain HTML files. Open `index.html` in a browser to explore the
 
 1. Replace the placeholder in `index.html`:
    ```js
-   const AUDIUS_API_KEY  = "YOUR_AUDIUS_API_KEY";
-   // const AUDIUS_API_SECRET = "YOUR_AUDIUS_API_SECRET"; // backend-only placeholder
-   ```
+ const AUDIUS_API_KEY  = "YOUR_AUDIUS_API_KEY";
+  // const AUDIUS_API_SECRET = "YOUR_AUDIUS_API_SECRET"; // backend-only placeholder
+  ```
 
 2. Open `index.html` in a browser (or host with GitHub Pages).
 
@@ -34,6 +34,14 @@ The app ships as plain HTML files. Open `index.html` in a browser to explore the
 ## Notes
 
 - Uses REST endpoints via `https://api.audius.co` to pick a host and call:
-  - `GET /v1/tracks/search?query=...`
-  - `GET /v1/tracks/{trackId}/stream`
+ - `GET /v1/tracks/search?query=...`
+ - `GET /v1/tracks/{trackId}/stream`
 - The API key is used **client-side (read-only)**. Keep any secrets on a backend only.
+
+## Authentication
+
+- Replace the placeholder client IDs in `index.html`:
+  - `GOOGLE_CLIENT_ID`
+  - `FACEBOOK_APP_ID`
+  - `INSTAGRAM_CLIENT_ID`
+- Clicking **Login** opens a modal to sign in via Google, Facebook, or Instagram.

--- a/index.html
+++ b/index.html
@@ -149,9 +149,23 @@
         border: 2px solid var(--color-secondary);
         box-shadow: 0 0 4px #000;
       }
+      .modal {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(0, 0, 0, 0.6);
+      }
+      .hidden {
+        display: none;
+      }
     </style>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js"></script>
   </head>
   <body>
+    <div id="fb-root"></div>
     <header class="glass grid" style="padding: 12px 16px; margin: 16px">
       <div
         class="row"
@@ -181,6 +195,20 @@
       />
       <div id="genres" class="row"></div>
     </header>
+
+    <div id="login-modal" class="modal hidden">
+      <div class="glass" style="padding:24px;max-width:320px;width:100%;">
+        <h2>Sign in</h2>
+        <div id="g_id_onload"
+             data-client_id="GOOGLE_CLIENT_ID"
+             data-context="signin"
+             data-callback="onGoogleSignIn"></div>
+        <div class="g_id_signin" data-type="standard" data-size="large"></div>
+        <div id="fb-login-btn" class="btn" style="margin-top:8px;">Login with Facebook</div>
+        <div id="insta-login-btn" class="btn" style="margin-top:8px;">Login with Instagram</div>
+        <div id="close-login" class="btn" style="margin-top:8px;background:transparent;border-color:var(--color-muted);color:var(--color-muted);">Close</div>
+      </div>
+    </div>
 
     <main id="results" class="grid" style="padding: 0 16px 140px"></main>
 
@@ -331,12 +359,23 @@
       let audioPlayer = document.querySelector("#player");
       const search = document.querySelector("#search");
       const login = document.querySelector("#login");
+      const loginModal = document.querySelector("#login-modal");
+      const fbLoginBtn = document.querySelector("#fb-login-btn");
+      const instaLoginBtn = document.querySelector("#insta-login-btn");
+      const closeLogin = document.querySelector("#close-login");
       const nextBtn = document.querySelector("#next");
       const shuffleBtn = document.querySelector("#shuffle");
       const queueLabel = document.querySelector("#queueLabel");
       const genresEl = document.querySelector("#genres");
       const GENRES = ["All", "UKG", "Grime", "House", "DNB"];
       let currentGenre = null;
+      if (window.location.hash.includes("access_token")) {
+        const token = new URLSearchParams(window.location.hash.substring(1)).get(
+          "access_token"
+        );
+        alert("Instagram access token: " + token);
+        window.location.hash = "";
+      }
       GENRES.forEach((g) => {
         const chip = document.createElement("button");
         chip.textContent = g;
@@ -535,7 +574,42 @@
         }
       };
 
-      login.onclick = () => alert("OAuth login coming soon");
+      login.onclick = () => loginModal.classList.remove("hidden");
+      closeLogin.onclick = () => loginModal.classList.add("hidden");
+      window.onGoogleSignIn = (res) => {
+        alert("Google login token: " + res.credential);
+        loginModal.classList.add("hidden");
+      };
+      window.fbAsyncInit = function () {
+        FB.init({
+          appId: "FACEBOOK_APP_ID",
+          cookie: true,
+          xfbml: true,
+          version: "v19.0",
+        });
+      };
+      fbLoginBtn.onclick = () => {
+        FB.login(
+          (response) => {
+            if (response.authResponse) {
+              alert("Logged in with Facebook");
+              loginModal.classList.add("hidden");
+            }
+          },
+          { scope: "public_profile,email" }
+        );
+      };
+      instaLoginBtn.onclick = () => {
+        const clientId = "INSTAGRAM_CLIENT_ID";
+        const redirectUri =
+          window.location.origin +
+          window.location.pathname +
+          window.location.search;
+        const url = `https://api.instagram.com/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(
+          redirectUri
+        )}&scope=user_profile&response_type=token`;
+        window.location.href = url;
+      };
 
       loadHome(currentGenre);
 


### PR DESCRIPTION
## Summary
- add OAuth login modal supporting Google, Facebook, and Instagram
- document social login setup in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6db846d80833394307aebc6411674