### PR TITLE
docs: add mobile installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ A sleek, HTML-only music browser that unifies **Audius** and **SoundCloud** trac
 1. Copy `.env.example` to `.env` and fill in your SoundCloud credentials.
 2. Serve the `public/` directory with any static host or open `public/index.html` directly in a browser.
 
+## Mobile installation
+
+To use the app like a native player on your phone:
+
+1. Open the hosted `public/index.html` in mobile Chrome (Android) or Safari (iOS).
+2. Use the browser menu and choose **Add to Home Screen**.
+3. Launch the new home screen icon; the PWA will run full screen and cache assets for offline use.
+
 ## Icons
 
 The app icon is loaded from an external source so no binary images live in the repo:


### PR DESCRIPTION
## Summary
- document steps to install the PWA on mobile devices via Add to Home Screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c96275c88333ba80c3521e8e5cb5