### PR TITLE
feat: persist likes and playlists

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,6 +354,61 @@
         };
       }
 
+      const LIKED_KEY = 'likedTracks';
+      const PLAYLIST_KEY = 'customPlaylists';
+
+      let likedTracks = [];
+      let customPlaylists = [];
+
+      function loadPreferences() {
+        try {
+          return {
+            liked: JSON.parse(localStorage.getItem(LIKED_KEY)) || [],
+            playlists: JSON.parse(localStorage.getItem(PLAYLIST_KEY)) || [],
+          };
+        } catch {
+          return { liked: [], playlists: [] };
+        }
+      }
+
+      function savePreferences() {
+        try {
+          localStorage.setItem(LIKED_KEY, JSON.stringify(likedTracks));
+          localStorage.setItem(
+            PLAYLIST_KEY,
+            JSON.stringify(customPlaylists)
+          );
+        } catch {
+          // Ignore storage write errors
+        }
+      }
+
+      function isLiked(track) {
+        return likedTracks.some(
+          (t) => t.id === track.id && t.platform === track.platform
+        );
+      }
+
+      function toggleLike(track) {
+        if (isLiked(track)) {
+          likedTracks = likedTracks.filter(
+            (t) => !(t.id === track.id && t.platform === track.platform)
+          );
+        } else {
+          likedTracks.push(track);
+        }
+        savePreferences();
+      }
+
+      function savePlaylist(pl) {
+        const idx = customPlaylists.findIndex((p) => p.name === pl.name);
+        if (idx > -1) customPlaylists[idx] = pl;
+        else customPlaylists.push(pl);
+        savePreferences();
+      }
+
+      ({ liked: likedTracks, playlists: customPlaylists } = loadPreferences());
+
       /** UI wiring **/
 
       const results = document.querySelector("#results");
@@ -433,6 +488,9 @@
               buttons.push(
                 `<button data-platform="${t.platform}" data-id="${t.id}" class="btn queue">➕</button>`,
               );
+            buttons.push(
+              `<button data-platform="${t.platform}" data-id="${t.id}" class="btn like">${isLiked(t) ? "♥" : "♡"}</button>`,
+            );
             if (includeLink)
               buttons.push(
                 `<a href="track.html?platform=${t.platform}&id=${t.id}" class="btn">Go To Track</a>`,
@@ -471,6 +529,14 @@
             const track = trackCache[key];
             queue.push(track);
             updateQueue();
+          };
+        });
+        container.querySelectorAll(".like").forEach((btn) => {
+          btn.onclick = () => {
+            const key = `${btn.dataset.platform}:${btn.dataset.id}`;
+            const track = trackCache[key];
+            toggleLike(track);
+            btn.textContent = isLiked(track) ? "♥" : "♡";
           };
         });
       }

--- a/public/app.js
+++ b/public/app.js
@@ -23,7 +23,63 @@ const els = {
   }
 };
 
-const state = { queue: [], idx: -1, token: null };
+const LIKED_KEY = 'likedTracks';
+const PLAYLIST_KEY = 'customPlaylists';
+
+function loadPreferences() {
+  try {
+    return {
+      liked: JSON.parse(localStorage.getItem(LIKED_KEY)) || [],
+      playlists: JSON.parse(localStorage.getItem(PLAYLIST_KEY)) || []
+    };
+  } catch {
+    return { liked: [], playlists: [] };
+  }
+}
+
+function savePreferences() {
+  try {
+    localStorage.setItem(LIKED_KEY, JSON.stringify(state.likedTracks));
+    localStorage.setItem(PLAYLIST_KEY, JSON.stringify(state.customPlaylists));
+  } catch {
+    // Swallow write errors (e.g. storage quota exceeded)
+  }
+}
+
+function isLiked(track) {
+  return state.likedTracks.some(
+    (t) => t.id === track.id && t.platform === track.platform
+  );
+}
+
+function toggleLike(track) {
+  if (isLiked(track)) {
+    state.likedTracks = state.likedTracks.filter(
+      (t) => !(t.id === track.id && t.platform === track.platform)
+    );
+  } else {
+    state.likedTracks.push(track);
+  }
+  savePreferences();
+}
+
+function savePlaylist(pl) {
+  const idx = state.customPlaylists.findIndex((p) => p.name === pl.name);
+  if (idx > -1) state.customPlaylists[idx] = pl;
+  else state.customPlaylists.push(pl);
+  savePreferences();
+}
+
+const state = {
+  queue: [],
+  idx: -1,
+  token: null,
+  likedTracks: [],
+  customPlaylists: []
+};
+
+({ liked: state.likedTracks, playlists: state.customPlaylists } =
+  loadPreferences());
 
 const RECENT_KEY = 'recentQueries';
 let recent = [];
@@ -98,10 +154,16 @@ function renderList(listEl, tracks){
       <span class="badge">${t.platform === 'audius' ? 'Audius' : 'SC'}</span>
       <div class="track-actions">
         <button class="btn play" ${t.isMrFlen ? '' : 'disabled title="Playback limited to Mr.FLEN"'}>Play</button>
+        <button class="btn secondary like">${isLiked(t) ? 'Unlike' : 'Like'}</button>
         <button class="btn secondary share" data-url="${t.permalink}">Share</button>
       </div>`;
     const playBtn = li.querySelector('.play');
     playBtn.onclick = () => t.isMrFlen && playFrom(tracks, i);
+    const likeBtn = li.querySelector('.like');
+    likeBtn.onclick = () => {
+      toggleLike(t);
+      likeBtn.textContent = isLiked(t) ? 'Unlike' : 'Like';
+    };
     const shareBtn = li.querySelector('.share');
     shareBtn.onclick = async () => {
       try {


### PR DESCRIPTION
## Summary
- persist liked tracks and custom playlists with localStorage
- hydrate UI state from stored preferences on load
- wire up like button to update storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b83890c858833397f15f68f2718d51