### PR TITLE
feat: add artist scope toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,6 +198,10 @@
         placeholder="Search tracks (Ctrl/⌘-K)"
         autocomplete="off"
       />
+      <div class="row" style="font-size:14px;gap:4px;align-items:center">
+        <input type="checkbox" id="all-artists-toggle" />
+        <label for="all-artists-toggle">Include all artists</label>
+      </div>
       <div id="genres" class="row"></div>
     </header>
 
@@ -284,7 +288,7 @@
         const res = await fetch(url);
         if (!res.ok) throw new Error("sc");
         const json = await res.json();
-        return json.filter((t) => t.user && t.user.username === MRFLEN_SC_USERNAME);
+        return json;
       }
 
       async function streamUrl(trackId) {
@@ -364,9 +368,15 @@
 
       const LIKED_KEY = 'likedTracks';
       const PLAYLIST_KEY = 'customPlaylists';
+      const SEARCH_ALL_KEY = 'searchAllArtists';
 
       let likedTracks = [];
       let customPlaylists = [];
+      let searchAllArtists = false;
+      try {
+        searchAllArtists =
+          localStorage.getItem(SEARCH_ALL_KEY) === 'true';
+      } catch {}
 
       function loadPreferences() {
         try {
@@ -422,6 +432,7 @@
       const results = document.querySelector("#results");
       let audioPlayer = document.querySelector("#player");
       const search = document.querySelector("#search");
+      const allArtistsToggle = document.querySelector("#all-artists-toggle");
       const login = document.querySelector("#login");
       const loginModal = document.querySelector("#login-modal");
       const fbLoginBtn = document.querySelector("#fb-login-btn");
@@ -434,6 +445,16 @@
       const shuffleBtn = document.querySelector("#shuffle");
       const queueLabel = document.querySelector("#queueLabel");
       const genresEl = document.querySelector("#genres");
+
+      allArtistsToggle.checked = searchAllArtists;
+      allArtistsToggle.addEventListener("change", () => {
+        searchAllArtists = allArtistsToggle.checked;
+        try {
+          localStorage.setItem(SEARCH_ALL_KEY, searchAllArtists);
+        } catch {}
+        if (search.value.trim()) search.dispatchEvent(new Event("input"));
+      });
+
       const { handleAuthSuccess } = window;
       const GENRES = ["All", "UKG", "Grime", "House", "DNB"];
       let currentGenre = null;
@@ -616,22 +637,35 @@
                 return [];
               }),
             ]);
-            const tracks = [
-              ...a
-                .filter((t) => t.user && t.user.handle === MRFLEN_AUDIUS_HANDLE)
-                .map(normalizeAudiusTrack),
-              ...s.map(normalizeSoundCloudTrack),
-            ];
+            let audiusTracks = a.map(normalizeAudiusTrack);
+            let scTracks = s.map(normalizeSoundCloudTrack);
+            if (!searchAllArtists) {
+              audiusTracks = audiusTracks.filter(
+                (t) => t.user && t.user.handle === MRFLEN_AUDIUS_HANDLE,
+              );
+              scTracks = scTracks.filter(
+                (t) => t.user && t.user.handle === MRFLEN_SC_USERNAME,
+              );
+            }
+            const tracks = [...audiusTracks, ...scTracks];
+            const scopeMessage = searchAllArtists
+              ? 'Showing all artists'
+              : 'Showing Mr.FLEN only';
             if (!tracks.length) {
               results.innerHTML =
-                '<div class="glass" style="padding:16px;">No Mr.FLEN tracks found.</div>';
+                `<div class="glass" style="padding:16px;">${scopeMessage}</div>` +
+                `<div class="glass" style="padding:16px;margin-top:8px;">No ${
+                  searchAllArtists ? '' : 'Mr.FLEN '
+                }tracks found.</div>`;
               if (scError)
                 results.innerHTML +=
                   '<div class="glass" style="padding:16px;margin-top:8px;">⚠️ SoundCloud results unavailable.</div>';
               return;
             }
             tracks.sort((a, b) => a.title.localeCompare(b.title));
-            let html = renderTracksList(tracks, true);
+            let html =
+              `<div class="glass" style="padding:16px;">${scopeMessage}</div>` +
+              renderTracksList(tracks, true);
             if (scError)
               html =
                 '<div class="glass" style="padding:16px;">⚠️ SoundCloud results unavailable.</div>' +

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A static music browser for Mr.FLEN that unifies Audius and SoundCloud tracks.",
   "private": true,
   "scripts": {
-    "test": "node --test"
+    "test": "jest"
   },
   "license": "MIT",
   "devDependencies": {

--- a/test/drive.test.js
+++ b/test/drive.test.js
@@ -1,6 +1,4 @@
 const { uploadWithToken, downloadWithToken, merge } = require('../public/drive.js');
-const { test } = require('node:test');
-const assert = require('assert');
 
 test('uploadWithToken creates file when none exists', async () => {
   const calls = [];
@@ -14,8 +12,8 @@ test('uploadWithToken creates file when none exists', async () => {
     }
   };
   await uploadWithToken('token', { a: 1 }, fetchMock);
-  assert.strictEqual(calls[0].url.includes('spaces=appDataFolder'), true);
-  assert.strictEqual(calls[1].opts.method, 'POST');
+  expect(calls[0].url.includes('spaces=appDataFolder')).toBe(true);
+  expect(calls[1].opts.method).toBe('POST');
 });
 
 test('uploadWithToken updates existing file', async () => {
@@ -28,7 +26,7 @@ test('uploadWithToken updates existing file', async () => {
     return { json: async () => ({ id: '1' }) };
   };
   await uploadWithToken('token', { a: 1 }, fetchMock);
-  assert.strictEqual(calls[1].opts.method, 'PATCH');
+  expect(calls[1].opts.method).toBe('PATCH');
 });
 
 test('downloadWithToken returns parsed data', async () => {
@@ -41,11 +39,11 @@ test('downloadWithToken returns parsed data', async () => {
     }
   };
   const data = await downloadWithToken('token', fetchMock);
-  assert.deepStrictEqual(data, { a: 1 });
+  expect(data).toEqual({ a: 1 });
 });
 
 test('merge prefers remote values', () => {
   const local = { a: 1, b: 2 };
   const remote = { a: 3, c: 4 };
-  assert.deepStrictEqual(merge(local, remote), { a: 3, b: 2, c: 4 });
+  expect(merge(local, remote)).toEqual({ a: 3, b: 2, c: 4 });
 });


### PR DESCRIPTION
## Summary
- add Include all artists toggle persisted in localStorage
- default search to Mr.FLEN and expand to all artists when toggled
- run tests with Jest

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b863814e3c8333b7f2746e6bad8bd1