### PR TITLE
feat: improve audio playback UX

### DIFF
--- a/__tests__/format-time.test.js
+++ b/__tests__/format-time.test.js
@@ -1,0 +1,8 @@
+const { formatTime } = require('../format-time');
+
+describe('formatTime', () => {
+  test('formats seconds to m:ss', () => {
+    expect(formatTime(0)).toBe('0:00');
+    expect(formatTime(65)).toBe('1:05');
+  });
+});

--- a/format-time.js
+++ b/format-time.js
@@ -1,0 +1,16 @@
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.formatTime = factory().formatTime;
+  }
+})(this, function () {
+  function formatTime(seconds) {
+    const s = Math.floor(seconds % 60)
+      .toString()
+      .padStart(2, '0');
+    const m = Math.floor(seconds / 60);
+    return `${m}:${s}`;
+  }
+  return { formatTime };
+});

--- a/index.html
+++ b/index.html
@@ -133,6 +133,15 @@
         color: #05060a;
         border-color: var(--color-primary);
       }
+      #progressContainer {
+        display: none;
+        align-items: center;
+        gap: 8px;
+        margin-top: 8px;
+      }
+      #progressBar {
+        flex: 1;
+      }
       .carousel {
         display: flex;
         gap: 16px;
@@ -246,8 +255,14 @@
       </div>
       <div id="playerContainer">
         <audio id="player" controls preload="none" style="width: 100%"></audio>
+        <div id="progressContainer" class="row" style="display:none">
+          <span id="currentTime">0:00</span>
+          <input type="range" id="progressBar" min="0" value="0" />
+          <span id="duration">0:00</span>
+        </div>
       </div>
     </footer>
+    <script src="format-time.js"></script>
     <script src="public/drive.js"></script>
     <script type="module">
       /**
@@ -445,6 +460,34 @@
       const shuffleBtn = document.querySelector("#shuffle");
       const queueLabel = document.querySelector("#queueLabel");
       const genresEl = document.querySelector("#genres");
+      const progressContainer = document.getElementById("progressContainer");
+      const progressBar = document.getElementById("progressBar");
+      const currentTimeEl = document.getElementById("currentTime");
+      const durationEl = document.getElementById("duration");
+
+      function attachPlayer(player) {
+        if (!player) {
+          progressContainer.style.display = "none";
+          return;
+        }
+        progressContainer.style.display = "flex";
+        progressBar.value = 0;
+        currentTimeEl.textContent = "0:00";
+        durationEl.textContent = "0:00";
+        player.addEventListener("timeupdate", () => {
+          progressBar.value = player.currentTime;
+          currentTimeEl.textContent = formatTime(player.currentTime);
+        });
+        player.addEventListener("loadedmetadata", () => {
+          progressBar.max = player.duration;
+          durationEl.textContent = formatTime(player.duration);
+        });
+        progressBar.oninput = (e) => {
+          player.currentTime = e.target.value;
+        };
+      }
+
+      attachPlayer(null);
 
       allArtistsToggle.checked = searchAllArtists;
       allArtistsToggle.addEventListener("change", () => {
@@ -497,10 +540,12 @@
           const { html } = await res.json();
           container.innerHTML = html;
           audioPlayer = null;
+          attachPlayer(null);
         } else {
           container.innerHTML =
             '<audio id="player" controls preload="none" style="width:100%"></audio>';
           audioPlayer = document.querySelector("#player");
+          attachPlayer(audioPlayer);
           const url = await streamUrl(track.id);
           audioPlayer.src = url;
           await audioPlayer.play();
@@ -754,6 +799,9 @@
         if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
           e.preventDefault();
           search.focus();
+        } else if (e.code === "Space" && e.target === document.body && audioPlayer) {
+          e.preventDefault();
+          audioPlayer.paused ? audioPlayer.play() : audioPlayer.pause();
         }
       });
       shuffleBtn.onclick = () => {

--- a/index.html
+++ b/index.html
@@ -460,14 +460,23 @@
       const shuffleBtn = document.querySelector("#shuffle");
       const queueLabel = document.querySelector("#queueLabel");
       const genresEl = document.querySelector("#genres");
-      const progressContainer = document.getElementById("progressContainer");
-      const progressBar = document.getElementById("progressBar");
-      const currentTimeEl = document.getElementById("currentTime");
-      const durationEl = document.getElementById("duration");
+      let progressContainer;
+      let progressBar;
+      let currentTimeEl;
+      let durationEl;
+
+      function cacheProgressEls() {
+        progressContainer = document.getElementById("progressContainer");
+        progressBar = document.getElementById("progressBar");
+        currentTimeEl = document.getElementById("currentTime");
+        durationEl = document.getElementById("duration");
+      }
+
+      cacheProgressEls();
 
       function attachPlayer(player) {
         if (!player) {
-          progressContainer.style.display = "none";
+          if (progressContainer) progressContainer.style.display = "none";
           return;
         }
         progressContainer.style.display = "flex";
@@ -539,11 +548,18 @@
           );
           const { html } = await res.json();
           container.innerHTML = html;
+          cacheProgressEls();
           audioPlayer = null;
           attachPlayer(null);
         } else {
-          container.innerHTML =
-            '<audio id="player" controls preload="none" style="width:100%"></audio>';
+          container.innerHTML = `
+            <audio id="player" controls preload="none" style="width:100%"></audio>
+            <div id="progressContainer" class="row" style="display:none">
+              <span id="currentTime">0:00</span>
+              <input type="range" id="progressBar" min="0" value="0" />
+              <span id="duration">0:00</span>
+            </div>`;
+          cacheProgressEls();
           audioPlayer = document.querySelector("#player");
           attachPlayer(audioPlayer);
           const url = await streamUrl(track.id);


### PR DESCRIPTION
## Summary
- add custom progress bar and keyboard shortcuts for audio playback
- provide `formatTime` utility with unit tests

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b887db904c8333a54ccc9a59701b7d