### PR TITLE
feat: add platform filters to search

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A sleek, HTML-only music browser that unifies **Audius** and **SoundCloud** trac
 
 - Dark, glassy dashboard UI.
 - Unified search (Audius + SoundCloud) with playback restricted to Mr.FLEN tracks.
+- Platform filters to show Audius and/or SoundCloud results.
 - Sticky player bar powered by the MediaSession API.
 - Installable PWA with offline shell caching.
 

--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -1,0 +1,21 @@
+const { filterTracks } = require('../public/filter');
+
+describe('filterTracks', () => {
+  const sample = [
+    { id: 1, platform: 'audius' },
+    { id: 2, platform: 'soundcloud' },
+    { id: 3, platform: 'audius' }
+  ];
+
+  test('returns all tracks when no platforms specified', () => {
+    expect(filterTracks(sample, [])).toHaveLength(3);
+  });
+
+  test('filters by selected platforms', () => {
+    const res = filterTracks(sample, ['audius']);
+    expect(res).toEqual([
+      { id: 1, platform: 'audius' },
+      { id: 3, platform: 'audius' }
+    ]);
+  });
+});

--- a/public/app.js
+++ b/public/app.js
@@ -16,6 +16,10 @@ const els = {
   palette: document.querySelector('#palette'),
   paletteInput: document.querySelector('#paletteInput'),
   paletteList: document.querySelector('#paletteList'),
+  platformFilters: {
+    audius: document.querySelector('#filter-audius'),
+    soundcloud: document.querySelector('#filter-soundcloud')
+  },
   analytics: {
     likes: document.querySelector('#likesCount'),
     reposts: document.querySelector('#repostsCount'),
@@ -68,6 +72,13 @@ function savePlaylist(pl) {
   if (idx > -1) state.customPlaylists[idx] = pl;
   else state.customPlaylists.push(pl);
   savePreferences();
+}
+
+function getSelectedPlatforms() {
+  const selected = [];
+  if (els.platformFilters.audius?.checked) selected.push('audius');
+  if (els.platformFilters.soundcloud?.checked) selected.push('soundcloud');
+  return selected;
 }
 
 const state = {
@@ -300,7 +311,8 @@ async function runSearch(){
   ]);
   const a = aRes.status === 'fulfilled' ? aRes.value : [];
   const s = sRes.status === 'fulfilled' ? sRes.value : [];
-  const results = [...a, ...s].filter(t => t.isMrFlen);
+  const combined = [...a, ...s].filter(t => t.isMrFlen);
+  const results = filterTracks(combined, getSelectedPlatforms());
   renderList(els.results, results);
   if(els.status) els.status.textContent = results.length ? '' : 'No tracks found.';
   els.searchBtn.disabled = false;

--- a/public/filter.js
+++ b/public/filter.js
@@ -1,0 +1,14 @@
+function filterTracks(tracks, platforms) {
+  if (!Array.isArray(platforms) || platforms.length === 0) {
+    return tracks;
+  }
+  return tracks.filter((t) => platforms.includes(t.platform));
+}
+
+if (typeof window !== 'undefined') {
+  window.filterTracks = filterTracks;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { filterTracks };
+}

--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,8 @@ body::before{
 .btn.loading{position:relative; pointer-events:none;}
 .btn.loading::after{content:""; position:absolute; right:12px; top:50%; width:16px; height:16px; margin-top:-8px; border:2px solid currentColor; border-top-color:transparent; border-radius:50%; animation:spin 1s linear infinite;}
 .btn.secondary{background:transparent; border-color:var(--brand); color:var(--brand);}
+.filters{display:flex; gap:8px; align-items:center;}
+.filters label{display:flex; align-items:center; gap:4px; font-size:14px;}
 .palette{position:fixed; inset:0; background:rgba(0,0,0,.6); display:flex; align-items:center; justify-content:center; z-index:1000;}
 .palette.hidden{display:none;}
 .palette-box{background:var(--panel); backdrop-filter:blur(var(--blur)); padding:16px; border-radius:var(--radius); box-shadow:var(--shadow); min-width:280px; max-width:90%;}
@@ -83,6 +85,10 @@ body::before{
     <div class="search">
       <input id="q" type="search" placeholder="Search for music…" aria-label="Search for music" autocomplete="off" />
       <button id="searchBtn" class="btn">Search</button>
+    </div>
+    <div class="filters" role="group" aria-label="Filter platforms">
+      <label><input type="checkbox" id="filter-audius" checked />Audius</label>
+      <label><input type="checkbox" id="filter-soundcloud" checked />SoundCloud</label>
     </div>
     <nav class="actions">
       <button id="connectSC" class="btn sc">Connect with SoundCloud</button>
@@ -173,6 +179,7 @@ body::before{
       "analytics": { "likes": 0, "reposts": 0, "followers": 0 }
     }
   </script>
+  <script src="filter.js"></script>
   <script src="app.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add platform filter checkboxes for Audius and SoundCloud
- filter track results by selected platform
- test track filtering logic

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b887db904c8333a54ccc9a59701b7d