### PR TITLE
fix: add Expo config for mobile app

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -1,0 +1,14 @@
+import type { ExpoConfig } from 'expo/config'
+
+const config: ExpoConfig = {
+  name: 'Mr FLEN Music',
+  slug: 'mr-flen-mobile',
+  version: '1.0.0',
+  orientation: 'portrait',
+  assetBundlePatterns: ['**/*'],
+  android: {
+    package: 'com.mrflen.music'
+  }
+}
+
+export default config


### PR DESCRIPTION
## Summary
- provide Expo config so mobile app can start via `pnpm start`

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm test`
- `cd mobile && pnpm lint`
- `cd mobile && pnpm typecheck`
- `cd mobile && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcceb6ce2c83339341058828b22efa