### PR TITLE
fix: add Expo config for mobile app

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -1,0 +1,10 @@
+import type { ConfigContext, ExpoConfig } from 'expo/config'
+
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  ...config,
+  name: 'Mr.FLEN Music',
+  slug: 'mr-flen-mobile',
+  version: '1.0.0',
+  orientation: 'portrait',
+  platforms: ['android']
+})


### PR DESCRIPTION
## Summary
- add Expo config to mobile package so `pnpm start` boots the app

## Testing
- `cd mobile && pnpm lint`
- `cd mobile && pnpm typecheck`
- `cd mobile && pnpm test`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcceb6ce2c83339341058828b22efa