### PR TITLE
fix(mobile): point Expo entry to AppEntry

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -2,7 +2,7 @@
   "name": "mr-flen-mobile",
   "version": "0.1.0",
   "private": true,
-  "main": "App.tsx",
+  "main": "expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- point mobile package.json main to Expo AppEntry.js

## Testing
- `pnpm install`
- `pnpm lint && pnpm typecheck && pnpm test`
- `pnpm expo start --android` *(fails: Failed to resolve the Android SDK path. Default install location not found: /root/Android/sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f36e343c8333832290097126162f