### PR TITLE
chore: pin React Native dependency versions

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -13,10 +13,10 @@
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.26",
     "expo": "~53.0.22",
-    "react": "19.1.1",
-    "react-native": "0.79.6",
-    "react-native-safe-area-context": "^5.6.1",
-    "react-native-screens": "^4.16.0"
+    "react": "19.0.0",
+    "react-native": "0.79.5",
+    "react-native-safe-area-context": "5.4.0",
+    "react-native-screens": "~4.11.1"
   },
   "devDependencies": {
     "@testing-library/jest-native": "^5.4.3",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -10,32 +10,32 @@ importers:
     dependencies:
       '@react-navigation/native':
         specifier: ^7.1.17
-        version: 7.1.17(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+        version: 7.1.17(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       '@react-navigation/native-stack':
         specifier: ^7.3.26
-        version: 7.3.26(@react-navigation/native@7.1.17(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native-safe-area-context@5.6.1(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native-screens@4.16.0(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+        version: 7.3.26(@react-navigation/native@7.1.17(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-screens@4.11.1(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       expo:
         specifier: ~53.0.22
-        version: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+        version: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react:
-        specifier: 19.1.1
-        version: 19.1.1
+        specifier: 19.0.0
+        version: 19.0.0
       react-native:
-        specifier: 0.79.6
-        version: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
+        specifier: 0.79.5
+        version: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
       react-native-safe-area-context:
-        specifier: ^5.6.1
-        version: 5.6.1(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+        specifier: 5.4.0
+        version: 5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-screens:
-        specifier: ^4.16.0
-        version: 4.16.0(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+        specifier: ~4.11.1
+        version: 4.11.1(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@testing-library/jest-native':
         specifier: ^5.4.3
-        version: 5.4.3(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react-test-renderer@19.0.0(react@19.1.1))(react@19.1.1)
+        version: 5.4.3(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react-test-renderer@19.0.0(react@19.0.0))(react@19.0.0)
       '@testing-library/react-native':
         specifier: ^13.3.3
-        version: 13.3.3(jest@29.7.0(@types/node@24.3.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react-test-renderer@19.0.0(react@19.1.1))(react@19.1.1)
+        version: 13.3.3(jest@29.7.0(@types/node@24.3.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react-test-renderer@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/jest':
         specifier: ^29.5.3
         version: 29.5.14
@@ -959,8 +959,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  '@react-native/assets-registry@0.79.6':
-    resolution: {integrity: sha512-UVSP1224PWg0X+mRlZNftV5xQwZGfawhivuW8fGgxNK9MS/U84xZ+16lkqcPh1ank6MOt239lIWHQ1S33CHgqA==}
+  '@react-native/assets-registry@0.79.5':
+    resolution: {integrity: sha512-N4Kt1cKxO5zgM/BLiyzuuDNquZPiIgfktEQ6TqJ/4nKA8zr4e8KJgU6Tb2eleihDO4E24HmkvGc73naybKRz/w==}
     engines: {node: '>=18'}
 
   '@react-native/babel-plugin-codegen@0.79.6':
@@ -973,14 +973,20 @@ packages:
     peerDependencies:
       '@babel/core': '*'
 
+  '@react-native/codegen@0.79.5':
+    resolution: {integrity: sha512-FO5U1R525A1IFpJjy+KVznEinAgcs3u7IbnbRJUG9IH/MBXi2lEU2LtN+JarJ81MCfW4V2p0pg6t/3RGHFRrlQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@babel/core': '*'
+
   '@react-native/codegen@0.79.6':
     resolution: {integrity: sha512-iRBX8Lgbqypwnfba7s6opeUwVyaR23mowh9ILw7EcT2oLz3RqMmjJdrbVpWhGSMGq2qkPfqAH7bhO8C7O+xfjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@babel/core': '*'
 
-  '@react-native/community-cli-plugin@0.79.6':
-    resolution: {integrity: sha512-ZHVst9vByGsegeaddkD2YbZ6NvYb4n3pD9H7Pit94u+NlByq2uBJghoOjT6EKqg+UVl8tLRdi88cU2pDPwdHqA==}
+  '@react-native/community-cli-plugin@0.79.5':
+    resolution: {integrity: sha512-ApLO1ARS8JnQglqS3JAHk0jrvB+zNW3dvNJyXPZPoygBpZVbf8sjvqeBiaEYpn8ETbFWddebC4HoQelDndnrrA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@react-native-community/cli': '*'
@@ -988,27 +994,38 @@ packages:
       '@react-native-community/cli':
         optional: true
 
+  '@react-native/debugger-frontend@0.79.5':
+    resolution: {integrity: sha512-WQ49TRpCwhgUYo5/n+6GGykXmnumpOkl4Lr2l2o2buWU9qPOwoiBqJAtmWEXsAug4ciw3eLiVfthn5ufs0VB0A==}
+    engines: {node: '>=18'}
+
   '@react-native/debugger-frontend@0.79.6':
     resolution: {integrity: sha512-lIK/KkaH7ueM22bLO0YNaQwZbT/oeqhaghOvmZacaNVbJR1Cdh/XAqjT8FgCS+7PUnbxA8B55NYNKGZG3O2pYw==}
+    engines: {node: '>=18'}
+
+  '@react-native/dev-middleware@0.79.5':
+    resolution: {integrity: sha512-U7r9M/SEktOCP/0uS6jXMHmYjj4ESfYCkNAenBjFjjsRWekiHE+U/vRMeO+fG9gq4UCcBAUISClkQCowlftYBw==}
     engines: {node: '>=18'}
 
   '@react-native/dev-middleware@0.79.6':
     resolution: {integrity: sha512-BK3GZBa9c7XSNR27EDRtxrgyyA3/mf1j3/y+mPk7Ac0Myu85YNrXnC9g3mL5Ytwo0g58TKrAIgs1fF2Q5Mn6mQ==}
     engines: {node: '>=18'}
 
-  '@react-native/gradle-plugin@0.79.6':
-    resolution: {integrity: sha512-C5odetI6py3CSELeZEVz+i00M+OJuFZXYnjVD4JyvpLn462GesHRh+Se8mSkU5QSaz9cnpMnyFLJAx05dokWbA==}
+  '@react-native/gradle-plugin@0.79.5':
+    resolution: {integrity: sha512-K3QhfFNKiWKF3HsCZCEoWwJPSMcPJQaeqOmzFP4RL8L3nkpgUwn74PfSCcKHxooVpS6bMvJFQOz7ggUZtNVT+A==}
     engines: {node: '>=18'}
 
-  '@react-native/js-polyfills@0.79.6':
-    resolution: {integrity: sha512-6wOaBh1namYj9JlCNgX2ILeGUIwc6OP6MWe3Y5jge7Xz9fVpRqWQk88Q5Y9VrAtTMTcxoX3CvhrfRr3tGtSfQw==}
+  '@react-native/js-polyfills@0.79.5':
+    resolution: {integrity: sha512-a2wsFlIhvd9ZqCD5KPRsbCQmbZi6KxhRN++jrqG0FUTEV5vY7MvjjUqDILwJd2ZBZsf7uiDuClCcKqA+EEdbvw==}
     engines: {node: '>=18'}
+
+  '@react-native/normalize-colors@0.79.5':
+    resolution: {integrity: sha512-nGXMNMclZgzLUxijQQ38Dm3IAEhgxuySAWQHnljFtfB0JdaMwpe0Ox9H7Tp2OgrEA+EMEv+Od9ElKlHwGKmmvQ==}
 
   '@react-native/normalize-colors@0.79.6':
     resolution: {integrity: sha512-0v2/ruY7eeKun4BeKu+GcfO+SHBdl0LJn4ZFzTzjHdWES0Cn+ONqKljYaIv8p9MV2Hx/kcdEvbY4lWI34jC/mQ==}
 
-  '@react-native/virtualized-lists@0.79.6':
-    resolution: {integrity: sha512-khA/Hrbb+rB68YUHrLubfLgMOD9up0glJhw25UE3Kntj32YDyuO0Tqc81ryNTcCekFKJ8XrAaEjcfPg81zBGPw==}
+  '@react-native/virtualized-lists@0.79.5':
+    resolution: {integrity: sha512-EUPM2rfGNO4cbI3olAbhPkIt3q7MapwCwAJBzUfWlZ/pu0PRNOnMQ1IvaXTf3TpeozXV52K1OdprLEI/kI5eUA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/react': ^19.0.0
@@ -3587,20 +3604,20 @@ packages:
       react: '*'
       react-native: '*'
 
-  react-native-safe-area-context@5.6.1:
-    resolution: {integrity: sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==}
+  react-native-safe-area-context@5.4.0:
+    resolution: {integrity: sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==}
     peerDependencies:
       react: '*'
       react-native: '*'
 
-  react-native-screens@4.16.0:
-    resolution: {integrity: sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==}
+  react-native-screens@4.11.1:
+    resolution: {integrity: sha512-F0zOzRVa3ptZfLpD0J8ROdo+y1fEPw+VBFq1MTY/iyDu08al7qFUO5hLMd+EYMda5VXGaTFCa8q7bOppUszhJw==}
     peerDependencies:
       react: '*'
       react-native: '*'
 
-  react-native@0.79.6:
-    resolution: {integrity: sha512-kvIWSmf4QPfY41HC25TR285N7Fv0Pyn3DAEK8qRL9dA35usSaxsJkHfw+VqnonqJjXOaoKCEanwudRAJ60TBGA==}
+  react-native@0.79.5:
+    resolution: {integrity: sha512-jVihwsE4mWEHZ9HkO1J2eUZSwHyDByZOqthwnGrVZCh6kTQBCm4v8dicsyDa6p0fpWNE5KicTcpX/XXl0ASJFg==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -3623,8 +3640,8 @@ packages:
     peerDependencies:
       react: ^19.0.0
 
-  react@19.1.1:
-    resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
+  react@19.0.0:
+    resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
 
   readable-stream@2.3.8:
@@ -5408,11 +5425,11 @@ snapshots:
 
   '@expo/sudo-prompt@9.3.2': {}
 
-  '@expo/vector-icons@14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)':
+  '@expo/vector-icons@14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
-      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
 
   '@expo/ws-tunnel@1.0.6': {}
 
@@ -5867,7 +5884,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@react-native/assets-registry@0.79.6': {}
+  '@react-native/assets-registry@0.79.5': {}
 
   '@react-native/babel-plugin-codegen@0.79.6(@babel/core@7.28.3)':
     dependencies:
@@ -5927,6 +5944,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@react-native/codegen@0.79.5(@babel/core@7.28.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      glob: 7.2.3
+      hermes-parser: 0.25.1
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      yargs: 17.7.2
+
   '@react-native/codegen@0.79.6(@babel/core@7.28.3)':
     dependencies:
       '@babel/core': 7.28.3
@@ -5937,9 +5963,9 @@ snapshots:
       nullthrows: 1.1.1
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.79.6(@react-native-community/cli@11.3.6(@babel/core@7.28.3))':
+  '@react-native/community-cli-plugin@0.79.5(@react-native-community/cli@11.3.6(@babel/core@7.28.3))':
     dependencies:
-      '@react-native/dev-middleware': 0.79.6
+      '@react-native/dev-middleware': 0.79.5
       chalk: 4.1.2
       debug: 2.6.9
       invariant: 2.2.4
@@ -5954,7 +5980,27 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@react-native/debugger-frontend@0.79.5': {}
+
   '@react-native/debugger-frontend@0.79.6': {}
+
+  '@react-native/dev-middleware@0.79.5':
+    dependencies:
+      '@isaacs/ttlcache': 1.4.1
+      '@react-native/debugger-frontend': 0.79.5
+      chrome-launcher: 0.15.2
+      chromium-edge-launcher: 0.2.0
+      connect: 3.7.0
+      debug: 2.6.9
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      open: 7.4.2
+      serve-static: 1.16.2
+      ws: 6.2.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@react-native/dev-middleware@0.79.6':
     dependencies:
@@ -5974,63 +6020,65 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native/gradle-plugin@0.79.6': {}
+  '@react-native/gradle-plugin@0.79.5': {}
 
-  '@react-native/js-polyfills@0.79.6': {}
+  '@react-native/js-polyfills@0.79.5': {}
+
+  '@react-native/normalize-colors@0.79.5': {}
 
   '@react-native/normalize-colors@0.79.6': {}
 
-  '@react-native/virtualized-lists@0.79.6(@types/react@19.0.14)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)':
+  '@react-native/virtualized-lists@0.79.5(@types/react@19.0.14)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
     optionalDependencies:
       '@types/react': 19.0.14
 
-  '@react-navigation/core@7.12.4(react@19.1.1)':
+  '@react-navigation/core@7.12.4(react@19.0.0)':
     dependencies:
       '@react-navigation/routers': 7.5.1
       escape-string-regexp: 4.0.0
       nanoid: 3.3.11
       query-string: 7.1.3
-      react: 19.1.1
+      react: 19.0.0
       react-is: 19.1.1
-      use-latest-callback: 0.2.4(react@19.1.1)
-      use-sync-external-store: 1.5.0(react@19.1.1)
+      use-latest-callback: 0.2.4(react@19.0.0)
+      use-sync-external-store: 1.5.0(react@19.0.0)
 
-  '@react-navigation/elements@2.6.4(@react-navigation/native@7.1.17(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native-safe-area-context@5.6.1(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)':
+  '@react-navigation/elements@2.6.4(@react-navigation/native@7.1.17(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@react-navigation/native': 7.1.17(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      '@react-navigation/native': 7.1.17(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       color: 4.2.3
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
-      react-native-safe-area-context: 5.6.1(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
-      use-latest-callback: 0.2.4(react@19.1.1)
-      use-sync-external-store: 1.5.0(react@19.1.1)
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
+      react-native-safe-area-context: 5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      use-latest-callback: 0.2.4(react@19.0.0)
+      use-sync-external-store: 1.5.0(react@19.0.0)
 
-  '@react-navigation/native-stack@7.3.26(@react-navigation/native@7.1.17(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native-safe-area-context@5.6.1(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native-screens@4.16.0(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)':
+  '@react-navigation/native-stack@7.3.26(@react-navigation/native@7.1.17(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-screens@4.11.1(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@react-navigation/elements': 2.6.4(@react-navigation/native@7.1.17(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native-safe-area-context@5.6.1(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
-      '@react-navigation/native': 7.1.17(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
-      react-native-safe-area-context: 5.6.1(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
-      react-native-screens: 4.16.0(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      '@react-navigation/elements': 2.6.4(@react-navigation/native@7.1.17(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      '@react-navigation/native': 7.1.17(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
+      react-native-safe-area-context: 5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native-screens: 4.11.1(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       warn-once: 0.1.1
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@react-navigation/native@7.1.17(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)':
+  '@react-navigation/native@7.1.17(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@react-navigation/core': 7.12.4(react@19.1.1)
+      '@react-navigation/core': 7.12.4(react@19.0.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.11
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
-      use-latest-callback: 0.2.4(react@19.1.1)
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
+      use-latest-callback: 0.2.4(react@19.0.0)
 
   '@react-navigation/routers@7.5.1':
     dependencies:
@@ -6061,25 +6109,25 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@testing-library/jest-native@5.4.3(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react-test-renderer@19.0.0(react@19.1.1))(react@19.1.1)':
+  '@testing-library/jest-native@5.4.3(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react-test-renderer@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       chalk: 4.1.2
       jest-diff: 29.7.0
       jest-matcher-utils: 29.7.0
       pretty-format: 29.7.0
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
-      react-test-renderer: 19.0.0(react@19.1.1)
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
+      react-test-renderer: 19.0.0(react@19.0.0)
       redent: 3.0.0
 
-  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@24.3.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react-test-renderer@19.0.0(react@19.1.1))(react@19.1.1)':
+  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@24.3.1))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react-test-renderer@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       jest-matcher-utils: 30.1.2
       picocolors: 1.1.1
       pretty-format: 30.0.5
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
-      react-test-renderer: 19.0.0(react@19.1.1)
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
+      react-test-renderer: 19.0.0(react@19.0.0)
       redent: 3.0.0
     optionalDependencies:
       jest: 29.7.0(@types/node@24.3.1)
@@ -7333,40 +7381,40 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  expo-asset@11.1.7(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
+  expo-asset@11.1.7(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
       '@expo/image-utils': 0.7.6
-      expo: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
-      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
+      expo: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)):
+  expo-constants@17.1.7(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)):
     dependencies:
       '@expo/config': 11.0.13
       '@expo/env': 1.0.7
-      expo: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
+      expo: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)):
+  expo-file-system@18.1.11(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)):
     dependencies:
-      expo: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
+      expo: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
 
-  expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+  expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      expo: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       fontfaceobserver: 2.3.0
-      react: 19.1.1
+      react: 19.0.0
 
-  expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1):
+  expo-keep-awake@14.1.4(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react@19.0.0):
     dependencies:
-      expo: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
+      expo: 53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
 
   expo-modules-autolinking@2.1.14:
     dependencies:
@@ -7382,7 +7430,7 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
+  expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.28.3
       '@expo/cli': 0.24.21(graphql@15.8.0)
@@ -7390,18 +7438,18 @@ snapshots:
       '@expo/config-plugins': 10.1.2
       '@expo/fingerprint': 0.13.4
       '@expo/metro-config': 0.20.17
-      '@expo/vector-icons': 14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.2(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       babel-preset-expo: 13.2.4(@babel/core@7.28.3)
-      expo-asset: 11.1.7(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
-      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))
-      expo-file-system: 18.1.11(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))
-      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1)
-      expo-keep-awake: 14.1.4(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      expo-asset: 11.1.7(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      expo-constants: 17.1.7(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))
+      expo-file-system: 18.1.11(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))
+      expo-font: 13.3.2(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      expo-keep-awake: 14.1.4(expo@53.0.22(@babel/core@7.28.3)(graphql@15.8.0)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react@19.0.0)
       expo-modules-autolinking: 2.1.14
       expo-modules-core: 2.5.0
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
-      react-native-edge-to-edge: 1.6.0(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
+      react-native-edge-to-edge: 1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       whatwg-url-without-unicode: 8.0.0-3
     transitivePeerDependencies:
       - '@babel/core'
@@ -9312,9 +9360,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  react-freeze@1.0.4(react@19.1.1):
+  react-freeze@1.0.4(react@19.0.0):
     dependencies:
-      react: 19.1.1
+      react: 19.0.0
 
   react-is@16.13.1: {}
 
@@ -9325,39 +9373,39 @@ snapshots:
 
   react-is@19.1.1: {}
 
-  react-native-edge-to-edge@1.6.0(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
+  react-native-edge-to-edge@1.6.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
 
-  react-native-is-edge-to-edge@1.2.1(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
+  react-native-is-edge-to-edge@1.2.1(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
 
-  react-native-safe-area-context@5.6.1(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
+  react-native-safe-area-context@5.4.0(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
-      react: 19.1.1
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
+      react: 19.0.0
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
 
-  react-native-screens@4.16.0(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1):
+  react-native-screens@4.11.1(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
-      react: 19.1.1
-      react-freeze: 1.0.4(react@19.1.1)
-      react-native: 0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1)
-      react-native-is-edge-to-edge: 1.2.1(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      react: 19.0.0
+      react-freeze: 1.0.4(react@19.0.0)
+      react-native: 0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0)
+      react-native-is-edge-to-edge: 1.2.1(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       warn-once: 0.1.1
 
-  react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1):
+  react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
-      '@react-native/assets-registry': 0.79.6
-      '@react-native/codegen': 0.79.6(@babel/core@7.28.3)
-      '@react-native/community-cli-plugin': 0.79.6(@react-native-community/cli@11.3.6(@babel/core@7.28.3))
-      '@react-native/gradle-plugin': 0.79.6
-      '@react-native/js-polyfills': 0.79.6
-      '@react-native/normalize-colors': 0.79.6
-      '@react-native/virtualized-lists': 0.79.6(@types/react@19.0.14)(react-native@0.79.6(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.1.1))(react@19.1.1)
+      '@react-native/assets-registry': 0.79.5
+      '@react-native/codegen': 0.79.5(@babel/core@7.28.3)
+      '@react-native/community-cli-plugin': 0.79.5(@react-native-community/cli@11.3.6(@babel/core@7.28.3))
+      '@react-native/gradle-plugin': 0.79.5
+      '@react-native/js-polyfills': 0.79.5
+      '@react-native/normalize-colors': 0.79.5
+      '@react-native/virtualized-lists': 0.79.5(@types/react@19.0.14)(react-native@0.79.5(@babel/core@7.28.3)(@react-native-community/cli@11.3.6(@babel/core@7.28.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -9377,7 +9425,7 @@ snapshots:
       nullthrows: 1.1.1
       pretty-format: 29.7.0
       promise: 8.3.0
-      react: 19.1.1
+      react: 19.0.0
       react-devtools-core: 6.1.5
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
@@ -9401,13 +9449,13 @@ snapshots:
   react-refresh@0.4.3:
     optional: true
 
-  react-test-renderer@19.0.0(react@19.1.1):
+  react-test-renderer@19.0.0(react@19.0.0):
     dependencies:
-      react: 19.1.1
+      react: 19.0.0
       react-is: 19.1.1
       scheduler: 0.25.0
 
-  react@19.1.1: {}
+  react@19.0.0: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -10068,13 +10116,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-latest-callback@0.2.4(react@19.1.1):
+  use-latest-callback@0.2.4(react@19.0.0):
     dependencies:
-      react: 19.1.1
+      react: 19.0.0
 
-  use-sync-external-store@1.5.0(react@19.1.1):
+  use-sync-external-store@1.5.0(react@19.0.0):
     dependencies:
-      react: 19.1.1
+      react: 19.0.0
 
   util-deprecate@1.0.2:
     optional: true


### PR DESCRIPTION
## Summary
- pin React, React Native, and related libraries to specific versions in mobile app
- update pnpm lockfile for the pinned versions

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm dlx expo-doctor` *(fails: connect ENETUNREACH 34.110.201.56:443)*
- `pnpm start`

------
https://chatgpt.com/codex/tasks/task_e_68c2f37083c883339fa2a72ec4308c81