### PR TITLE
fix: handle different created date fields when sorting

### DIFF
--- a/__tests__/sort-tracks.test.js
+++ b/__tests__/sort-tracks.test.js
@@ -37,4 +37,15 @@ describe('sortTracks', () => {
     );
     expect(sorted.map(t => t.title)).toEqual(['New', 'Old']);
   });
+
+  test('sorts by latest when using created_at field', () => {
+    const sorted = sortTracks(
+      [
+        { title: 'Old', created_at: '2020-01-01' },
+        { title: 'New', created_at: '2024-01-01' }
+      ],
+      'latest'
+    );
+    expect(sorted.map(t => t.title)).toEqual(['New', 'Old']);
+  });
 });

--- a/public/sort-tracks.js
+++ b/public/sort-tracks.js
@@ -15,7 +15,15 @@
         return (b.plays || 0) - (a.plays || 0);
       }
       if (criterion === 'latest') {
-        return new Date(b.createdAt || 0) - new Date(a.createdAt || 0);
+        const parseDate = (t) =>
+          new Date(
+            t.createdAt ||
+              t.created_at ||
+              t.releaseDate ||
+              t.release_date ||
+              0
+          );
+        return parseDate(b) - parseDate(a);
       }
       return (a.title || '').localeCompare(b.title || '');
     });


### PR DESCRIPTION
## Summary
- ensure latest sorting uses multiple created-date fields across APIs
- add test coverage for created_at field sorting

## Testing
- `pnpm lint` (fails: Command "lint" not found)
- `pnpm typecheck` (fails: Command "typecheck" not found)
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3a34fbe588333b24f9dada7c42639