### PR TITLE
fix: support Google OAuth token exchange

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -20,4 +20,20 @@ describe('OAuth helpers', () => {
     expect(mockFetch).toHaveBeenCalled();
     expect(token).toBe('abc');
   });
+
+  test('exchangeCodeForToken handles Google provider', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ access_token: 'def' })
+    });
+    const token = await exchangeCodeForToken('google', 'CODE', mockFetch);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://oauth2.googleapis.com/token',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: expect.stringContaining('code=CODE')
+      })
+    );
+    expect(token).toBe('def');
+  });
 });

--- a/auth.js
+++ b/auth.js
@@ -9,7 +9,8 @@ async function exchangeCodeForToken(provider, code, fetchImpl = fetch) {
   const endpoints = {
     x: 'https://api.twitter.com/2/oauth2/token',
     snapchat: 'https://accounts.snapchat.com/accounts/oauth2/token',
-    tiktok: 'https://open-api.tiktok.com/oauth/access_token'
+    tiktok: 'https://open-api.tiktok.com/oauth/access_token',
+    google: 'https://oauth2.googleapis.com/token'
   };
   const url = endpoints[provider];
   if (!url) throw new Error('Unknown provider');


### PR DESCRIPTION
## Summary
- add Google token endpoint to exchangeCodeForToken
- cover Google exchange in auth tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3ac0644708333878eff7e53ca7fcf