### PR TITLE
feat: list months from first release

### DIFF
--- a/__tests__/filter-tracks.test.js
+++ b/__tests__/filter-tracks.test.js
@@ -46,8 +46,16 @@ describe('listMonths', () => {
     { createdAt: 'invalid' },
   ];
 
-  test('extracts unique months sorted desc', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-03-01'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test('lists months from first release to current month', () => {
     const months = listMonths(tracks);
-    expect(months).toEqual(['2024-02', '2024-01']);
+    expect(months).toEqual(['2024-01', '2024-02', '2024-03']);
   });
 });

--- a/public/filter-tracks.js
+++ b/public/filter-tracks.js
@@ -29,15 +29,21 @@
 
   function listMonths(tracks) {
     if (!Array.isArray(tracks)) return [];
-    const set = new Set();
-    tracks.forEach((t) => {
-      if (!t.createdAt) return;
-      const d = new Date(t.createdAt);
-      if (Number.isNaN(d.getTime())) return;
-      const m = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
-      set.add(m);
-    });
-    return Array.from(set).sort().reverse();
+    const dates = tracks
+      .map((t) => new Date(t.createdAt))
+      .filter((d) => !Number.isNaN(d.getTime()))
+      .sort((a, b) => a - b);
+    if (!dates.length) return [];
+    const first = new Date(dates[0].getFullYear(), dates[0].getMonth(), 1);
+    const now = new Date();
+    const months = [];
+    const current = new Date(first);
+    while (current <= now) {
+      const m = `${current.getFullYear()}-${String(current.getMonth() + 1).padStart(2, '0')}`;
+      months.push(m);
+      current.setMonth(current.getMonth() + 1);
+    }
+    return months;
   }
 
   return { filterByGenre, filterByMonth, listMonths };

--- a/releases.html
+++ b/releases.html
@@ -94,7 +94,7 @@
         opt.textContent = m;
         monthSelect.appendChild(opt);
       });
-      const month = selectedMonth || months[0] || "";
+      const month = selectedMonth || months[months.length - 1] || "";
       if (month) monthSelect.value = month;
       function render(monthVal) {
         let tracks = window.filterByMonth(userTracks, monthVal);


### PR DESCRIPTION
## Summary
- generate sequential months from first release to current date for dropdowns
- default releases page to latest month
- add unit test for month list generation

## Testing
- `pnpm lint && pnpm typecheck && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c40b4a7a488333b70b63e59a5f68bf