### PR TITLE
feat: add search scope toggle with persistence

### DIFF
--- a/__tests__/search-preferences.test.js
+++ b/__tests__/search-preferences.test.js
@@ -1,0 +1,17 @@
+const { getSearchAll, setSearchAll, SEARCH_ALL_KEY } = require('../public/search-preferences');
+
+describe('search preferences', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('defaults to true when unset', () => {
+    expect(getSearchAll()).toBe(true);
+  });
+
+  test('persists toggle state', () => {
+    setSearchAll(false);
+    expect(localStorage.getItem(SEARCH_ALL_KEY)).toBe('false');
+    expect(getSearchAll()).toBe(false);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
         autocomplete="off"
       />
       <div class="row" style="font-size:14px;gap:4px;align-items:center">
-        <input type="checkbox" id="all-artists-toggle" />
+        <input type="checkbox" id="all-artists-toggle" checked />
         <label for="all-artists-toggle">Include all artists</label>
       </div>
       <div id="genres" class="row"></div>
@@ -350,6 +350,7 @@
       <script src="auth.js"></script>
       <script src="public/queue-utils.js"></script>
       <script src="spotify.js"></script>
+      <script src="public/search-preferences.js"></script>
       <script type="module">
       /**
        * Audius REST integration for Mr.FLENs Music Finder.
@@ -518,15 +519,10 @@
 
       const LIKED_KEY = 'likedTracks';
       const PLAYLIST_KEY = 'customPlaylists';
-      const SEARCH_ALL_KEY = 'searchAllArtists';
 
       let likedTracks = [];
       let customPlaylists = [];
-      let searchAllArtists = false;
-      try {
-        searchAllArtists =
-          localStorage.getItem(SEARCH_ALL_KEY) === 'true';
-      } catch {}
+      let searchAllArtists = window.SearchPreferences.getSearchAll();
 
       function loadPreferences() {
         try {
@@ -681,9 +677,7 @@
       allArtistsToggle.checked = searchAllArtists;
       allArtistsToggle.addEventListener("change", () => {
         searchAllArtists = allArtistsToggle.checked;
-        try {
-          localStorage.setItem(SEARCH_ALL_KEY, searchAllArtists);
-        } catch {}
+        window.SearchPreferences.setSearchAll(searchAllArtists);
         if (search.value.trim()) search.dispatchEvent(new Event("input"));
       });
 

--- a/public/search-preferences.js
+++ b/public/search-preferences.js
@@ -1,0 +1,29 @@
+(function(root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.SearchPreferences = factory();
+  }
+})(this, function() {
+  const SEARCH_ALL_KEY = 'searchAllArtists';
+
+  function getSearchAll() {
+    try {
+      const stored = localStorage.getItem(SEARCH_ALL_KEY);
+      return stored === null ? true : stored === 'true';
+    } catch {
+      return true;
+    }
+  }
+
+  function setSearchAll(val) {
+    try {
+      localStorage.setItem(SEARCH_ALL_KEY, String(val));
+    } catch {
+      // ignore storage errors
+    }
+    return val;
+  }
+
+  return { SEARCH_ALL_KEY, getSearchAll, setSearchAll };
+});


### PR DESCRIPTION
## Summary
- add persistent SearchPreferences helper defaulting to show all artists
- wire UI toggle to new helper and default to inclusive search
- test preference persistence and default behaviour

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c40b722d388333b2d10c9f3012f844