### PR TITLE
feat: style play toggles with donut image

### DIFF
--- a/index (2).html
+++ b/index (2).html
@@ -6,6 +6,7 @@
   <title>Mr.FLEN's Music Finder</title>
   <meta name="theme-color" content="#0b1017">
   <link rel="manifest" href="manifest.webmanifest">
+  <link rel="stylesheet" href="style%20(3).css">
   
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -432,7 +433,7 @@
           id="playPauseBtn"
           class="glass-panel w-12 h-12 flex items-center justify-center rounded-full bg-brand hover:bg-brand/90 transition"
         >
-          <i data-feather="play" class="w-5 h-5 translate-x-px"></i>
+          <img src="https://videos.openai.com/vg-assets/assets%2Ftask_01k50ne2sqfa7bt7ysj4ysber1%2F1757737878_img_1.webp?st=2025-09-13T02%3A52%3A19Z&amp;se=2025-09-19T03%3A52%3A19Z&amp;sks=b&amp;skt=2025-09-13T02%3A52%3A19Z&amp;ske=2025-09-19T03%3A52%3A19Z&amp;sktid=a48cca56-e6da-484e-a814-9c849652bcb3&amp;skoid=aa5ddad1-c91a-4f0a-9aca-e20682cc8969&amp;skv=2019-02-02&amp;sv=2018-11-09&amp;sr=b&amp;sp=r&amp;spr=https%2Chttp&amp;sig=hqf3g2w%2Fc8eIE8G4lB%2Bqjuu5AM%2FKFniZ%2F7brwsJ1318%3D&amp;az=oaivgprodsc" alt="Play" class="w-5 h-5 translate-x-px" />
         </button>
         <button class="glass-panel w-8 h-8 flex items-center justify-center rounded-full hover:bg-black/10 transition">
           <i data-feather="skip-forward" class="w-4 h-4"></i>
@@ -531,7 +532,7 @@
             id="fullPlayerPlay"
             class="glass-panel w-16 h-16 flex items-center justify-center rounded-full bg-brand hover:bg-brand/90 transition"
           >
-            <i data-feather="play" class="w-6 h-6 translate-x-px"></i>
+            <img src="https://videos.openai.com/vg-assets/assets%2Ftask_01k50ne2sqfa7bt7ysj4ysber1%2F1757737878_img_1.webp?st=2025-09-13T02%3A52%3A19Z&amp;se=2025-09-19T03%3A52%3A19Z&amp;sks=b&amp;skt=2025-09-13T02%3A52%3A19Z&amp;ske=2025-09-19T03%3A52%3A19Z&amp;sktid=a48cca56-e6da-484e-a814-9c849652bcb3&amp;skoid=aa5ddad1-c91a-4f0a-9aca-e20682cc8969&amp;skv=2019-02-02&amp;sv=2018-11-09&amp;sr=b&amp;sp=r&amp;spr=https%2Chttp&amp;sig=hqf3g2w%2Fc8eIE8G4lB%2Bqjuu5AM%2FKFniZ%2F7brwsJ1318%3D&amp;az=oaivgprodsc" alt="Play" class="w-6 h-6 translate-x-px" />
           </button>
           <button class="glass-panel w-10 h-10 flex items-center justify-center rounded-full hover:bg-black/10 transition">
             <i data-feather="skip-forward" class="w-5 h-5"></i>
@@ -851,7 +852,7 @@
       
       // Show playing state
       const playButton = document.getElementById('playPauseBtn');
-      playButton.innerHTML = '<i data-feather="pause" class="w-5 h-5"></i>';
+      playButton.innerHTML = '<img src="https://videos.openai.com/vg-assets/assets%2Ftask_01k50ne2sqfa7bt7ysj4ysber1%2F1757737878_img_1.webp?st=2025-09-13T02%3A52%3A19Z&amp;se=2025-09-19T03%3A52%3A19Z&amp;sks=b&amp;skt=2025-09-13T02%3A52%3A19Z&amp;ske=2025-09-19T03%3A52%3A19Z&amp;sktid=a48cca56-e6da-484e-a814-9c849652bcb3&amp;skoid=aa5ddad1-c91a-4f0a-9aca-e20682cc8969&amp;skv=2019-02-02&amp;sv=2018-11-09&amp;sr=b&amp;sp=r&amp;spr=https%2Chttp&amp;sig=hqf3g2w%2Fc8eIE8G4lB%2Bqjuu5AM%2FKFniZ%2F7brwsJ1318%3D&amp;az=oaivgprodsc" alt="Pause" class="w-5 h-5" />';
       feather.replace();
       
       // Fetch and play stream


### PR DESCRIPTION
## Summary
- link extra stylesheet to advanced index page
- swap play/pause icons for donut image toggle
- wire script to maintain donut icon when track starts
- load donut image from remote URL and remove bundled asset

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4ef5398848333952085e4da317156