### PR TITLE
feat: add previous track control

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A sleek, HTML-only music browser that unifies **Audius**, **SoundCloud**, and **
 - Dark, glassy dashboard UI.
 - Unified search (Audius + SoundCloud + Spotify) with playback restricted to Mr.FLEN tracks.
 - Sticky player bar powered by the MediaSession API.
+- Playback controls include previous/next, shuffle, and queue management.
 - Installable PWA with offline shell caching.
 - Light/dark theme toggle across pages with preference stored in local storage.
 - Player supports mute toggle and keyboard shortcuts for play/pause and mute.

--- a/__tests__/queue-utils.test.js
+++ b/__tests__/queue-utils.test.js
@@ -3,6 +3,7 @@ const {
   removeFromQueue,
   moveInQueue,
   adjustIndexOnRemove,
+  previousIndex,
 } = require('../public/queue-utils');
 
 
@@ -31,6 +32,12 @@ describe('queue-utils', () => {
 
   test('adjustIndexOnRemove unchanged when removed after current', () => {
     expect(adjustIndexOnRemove(1, 2)).toBe(1);
+  });
+
+  test('previousIndex steps back when possible', () => {
+    expect(previousIndex(3)).toBe(2);
+    expect(previousIndex(0)).toBe(0);
+    expect(previousIndex(-1)).toBe(-1);
   });
 
 });

--- a/index.html
+++ b/index.html
@@ -310,9 +310,10 @@
         <div class="row" style="justify-content: space-between">
           <span id="queueLabel">Queue: 0</span>
           <div class="row" style="gap: 4px">
-            <button id="showQueue" class="btn">📃</button>
-            <button id="shuffle" class="btn">🔀</button>
-            <button id="next" class="btn">⏭</button>
+            <button id="showQueue" class="btn" aria-label="Show queue">📃</button>
+            <button id="shuffle" class="btn" aria-label="Shuffle">🔀</button>
+            <button id="prev" class="btn" aria-label="Previous">⏮</button>
+            <button id="next" class="btn" aria-label="Next">⏭</button>
           </div>
         </div>
       <div id="playerContainer">
@@ -615,6 +616,7 @@
         if (!initGoogleAuth()) setTimeout(initGoogle, 100);
       })();
         const nextBtn = document.querySelector("#next");
+        const prevBtn = document.querySelector("#prev");
         const shuffleBtn = document.querySelector("#shuffle");
         const queueLabel = document.querySelector("#queueLabel");
         const showQueueBtn = document.getElementById("showQueue");
@@ -624,8 +626,13 @@
         const savePlaylistBtn = document.getElementById("savePlaylistBtn");
         const playlistList = document.getElementById("playlistList");
         const genresEl = document.querySelector("#genres");
-        const { addToQueue, removeFromQueue, moveInQueue, adjustIndexOnRemove } =
-          queueUtils;
+        const {
+          addToQueue,
+          removeFromQueue,
+          moveInQueue,
+          adjustIndexOnRemove,
+          previousIndex,
+        } = queueUtils;
       let progressContainer;
       let progressBar;
       let currentTimeEl;
@@ -1118,6 +1125,14 @@
       nextBtn.onclick = () => {
         if (currentIndex + 1 < queue.length) {
           currentIndex++;
+          playTrack(queue[currentIndex]);
+        }
+      };
+
+      prevBtn.onclick = () => {
+        const idx = previousIndex(currentIndex);
+        if (idx !== currentIndex && idx >= 0 && idx < queue.length) {
+          currentIndex = idx;
           playTrack(queue[currentIndex]);
         }
       };

--- a/public/queue-utils.js
+++ b/public/queue-utils.js
@@ -36,5 +36,15 @@
     return removedIndex <= currentIndex ? currentIndex - 1 : currentIndex;
   }
 
-  return { addToQueue, removeFromQueue, moveInQueue, adjustIndexOnRemove };
+  function previousIndex(currentIndex) {
+    return currentIndex > 0 ? currentIndex - 1 : currentIndex;
+  }
+
+  return {
+    addToQueue,
+    removeFromQueue,
+    moveInQueue,
+    adjustIndexOnRemove,
+    previousIndex,
+  };
 });


### PR DESCRIPTION
## Summary
- add previous/next navigation for queue playback
- document expanded playback controls
- expose queue utility to step backward with tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c72b972c2c83339ce7b725487e87db