### PR TITLE
fix: support spotify auth in browser contexts

### DIFF
--- a/__tests__/spotify.test.js
+++ b/__tests__/spotify.test.js
@@ -1,12 +1,30 @@
-process.env.SPOTIFY_CLIENT_ID = 'id';
-process.env.SPOTIFY_CLIENT_SECRET = 'secret';
-const {
-  searchSpotify,
-  normalizeSpotifyTrack,
-} = require('../spotify');
-
 describe('spotify integration', () => {
+  let originalBuffer;
+  let originalBtoa;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.SPOTIFY_CLIENT_ID = 'id';
+    process.env.SPOTIFY_CLIENT_SECRET = 'secret';
+    originalBuffer = global.Buffer;
+    originalBtoa = global.btoa;
+  });
+
+  afterEach(() => {
+    if (typeof originalBuffer === 'undefined') {
+      delete global.Buffer;
+    } else {
+      global.Buffer = originalBuffer;
+    }
+    if (typeof originalBtoa === 'undefined') {
+      delete global.btoa;
+    } else {
+      global.btoa = originalBtoa;
+    }
+  });
+
   test('searchSpotify retrieves tracks with token', async () => {
+    const { searchSpotify, normalizeSpotifyTrack } = require('../spotify');
     const fetchMock = jest
       .fn()
       .mockResolvedValueOnce({
@@ -40,6 +58,32 @@ describe('spotify integration', () => {
         id: '1',
         title: 'Song',
         streamUrl: 'prev',
+      }),
+    );
+  });
+
+  test('getSpotifyToken falls back to btoa when Buffer is unavailable', async () => {
+    const nodeBuffer = originalBuffer;
+    const expected = nodeBuffer.from('id:secret', 'utf-8').toString('base64');
+    global.Buffer = undefined;
+    global.btoa = jest.fn((value) => nodeBuffer.from(value, 'binary').toString('base64'));
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'tok', expires_in: 3600 }),
+    });
+
+    const { getSpotifyToken } = require('../spotify');
+
+    await getSpotifyToken(fetchMock);
+
+    expect(global.btoa).toHaveBeenCalledWith('id:secret');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://accounts.spotify.com/api/token',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Basic ${expected}`,
+        }),
       }),
     );
   });


### PR DESCRIPTION
## Summary
- add an environment-agnostic base64 encoder so Spotify auth works when `Buffer` is unavailable
- use the new encoder when fetching Spotify tokens to avoid browser crashes
- extend the Spotify test suite to cover the btoa fallback logic

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca1bc9fa6083338f9102f83b360fdc