### PR TITLE
fix: derive month filters from track data

### DIFF
--- a/__tests__/filter-tracks.test.js
+++ b/__tests__/filter-tracks.test.js
@@ -54,8 +54,18 @@ describe('listMonths', () => {
     jest.useRealTimers();
   });
 
-  test('lists months from first release to current month', () => {
+  test('lists months from earliest to latest release month present', () => {
     const months = listMonths(tracks);
-    expect(months).toEqual(['2024-01', '2024-02', '2024-03']);
+    expect(months).toEqual(['2024-01', '2024-02']);
+  });
+
+  test('uses track metadata fields instead of current date', () => {
+    const extraTracks = [
+      { release_date: '2024-01-01' },
+      { release_date: '2024-03-15' },
+      { created_at: '2024-05-01' },
+    ];
+    const months = listMonths(extraTracks);
+    expect(months).toEqual(['2024-01', '2024-02', '2024-03', '2024-04', '2024-05']);
   });
 });

--- a/public/filter-tracks.js
+++ b/public/filter-tracks.js
@@ -29,16 +29,34 @@
 
   function listMonths(tracks) {
     if (!Array.isArray(tracks)) return [];
+
+    const toDate = (value) => {
+      if (!value) return null;
+      const d = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+      return Number.isNaN(d.getTime()) ? null : d;
+    };
+
+    const fields = ['createdAt', 'created_at', 'releaseDate', 'release_date'];
+
     const dates = tracks
-      .map((t) => new Date(t.createdAt))
-      .filter((d) => !Number.isNaN(d.getTime()))
+      .map((track) => {
+        for (let i = 0; i < fields.length; i += 1) {
+          const parsed = toDate(track?.[fields[i]]);
+          if (parsed) return parsed;
+        }
+        return null;
+      })
+      .filter(Boolean)
       .sort((a, b) => a - b);
+
     if (!dates.length) return [];
+
     const first = new Date(dates[0].getFullYear(), dates[0].getMonth(), 1);
-    const now = new Date();
+    const last = new Date(dates[dates.length - 1].getFullYear(), dates[dates.length - 1].getMonth(), 1);
+
     const months = [];
     const current = new Date(first);
-    while (current <= now) {
+    while (current <= last) {
       const m = `${current.getFullYear()}-${String(current.getMonth() + 1).padStart(2, '0')}`;
       months.push(m);
       current.setMonth(current.getMonth() + 1);


### PR DESCRIPTION
## Summary
- ensure month list generation derives its range from the actual track metadata rather than the current date
- normalise release dates across supported metadata fields when deriving months
- extend filter tests to cover new behaviour and metadata scenarios

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca34f71f8483338b11c69224552466