### PR TITLE
fix: harden auth and playback utilities

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -18,11 +18,33 @@ describe('OAuth helpers', () => {
 
   test('exchangeCodeForToken uses fetch and returns token', async () => {
     const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: () => Promise.resolve({ access_token: 'abc' })
     });
     const token = await exchangeCodeForToken('x', 'CODE', mockFetch);
     expect(mockFetch).toHaveBeenCalled();
     expect(token).toBe('abc');
+  });
+
+  test('exchangeCodeForToken throws when response not ok', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: jest.fn()
+    });
+    await expect(exchangeCodeForToken('x', 'CODE', mockFetch)).rejects.toThrow(
+      'HTTP 400'
+    );
+  });
+
+  test('exchangeCodeForToken throws when token missing', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({})
+    });
+    await expect(exchangeCodeForToken('x', 'CODE', mockFetch)).rejects.toThrow(
+      'access_token'
+    );
   });
 
   test('initGoogleAuth initialises Google sign-in when library available', () => {

--- a/__tests__/format-time.test.js
+++ b/__tests__/format-time.test.js
@@ -5,4 +5,10 @@ describe('formatTime', () => {
     expect(formatTime(0)).toBe('0:00');
     expect(formatTime(65)).toBe('1:05');
   });
+
+  test('clamps invalid or negative input to zero', () => {
+    expect(formatTime(-10)).toBe('0:00');
+    expect(formatTime('invalid')).toBe('0:00');
+    expect(formatTime(Number.POSITIVE_INFINITY)).toBe('0:00');
+  });
 });

--- a/__tests__/queue-utils.test.js
+++ b/__tests__/queue-utils.test.js
@@ -34,6 +34,11 @@ describe('queue-utils', () => {
     expect(adjustIndexOnRemove(1, 2)).toBe(1);
   });
 
+  test('adjustIndexOnRemove ignores invalid removal indices', () => {
+    expect(adjustIndexOnRemove(1, -1)).toBe(1);
+    expect(adjustIndexOnRemove(-1, 0)).toBe(-1);
+  });
+
   test('previousIndex steps back when possible', () => {
     expect(previousIndex(3)).toBe(2);
     expect(previousIndex(0)).toBe(0);

--- a/auth.js
+++ b/auth.js
@@ -16,13 +16,40 @@ async function exchangeCodeForToken(provider, code, fetchImpl = fetch) {
   };
   const url = endpoints[provider];
   if (!url) throw new Error("Unknown provider");
-  const res = await fetchImpl(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: `code=${encodeURIComponent(code)}`,
-  });
-  const data = await res.json();
-  return data.access_token;
+  let res;
+  try {
+    res = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: `code=${encodeURIComponent(code)}`,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to exchange code for token: ${message}`);
+  }
+
+  if (!res || typeof res.ok !== "boolean") {
+    throw new Error("Failed to exchange code for token: Invalid response");
+  }
+
+  if (!res.ok) {
+    const status = "status" in res ? res.status : "unknown";
+    throw new Error(`Failed to exchange code for token: HTTP ${status}`);
+  }
+
+  let data;
+  try {
+    data = await res.json();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse token response: ${message}`);
+  }
+
+  const token = data && typeof data.access_token === "string" ? data.access_token : "";
+  if (!token) {
+    throw new Error("Token response missing access_token");
+  }
+  return token;
 }
 
 function initGoogleAuth(clientId, callback) {

--- a/format-time.js
+++ b/format-time.js
@@ -1,11 +1,16 @@
 // @ts-nocheck
 
 function formatTime(seconds) {
-  const s = Math.floor(seconds % 60)
-    .toString()
-    .padStart(2, "0");
-  const m = Math.floor(seconds / 60);
-  return `${m}:${s}`;
+  const numericSeconds = Number(seconds);
+  if (!Number.isFinite(numericSeconds) || numericSeconds <= 0) {
+    return "0:00";
+  }
+
+  const wholeSeconds = Math.floor(numericSeconds);
+  const minutes = Math.floor(wholeSeconds / 60);
+  const remainder = wholeSeconds % 60;
+
+  return `${minutes}:${String(remainder).padStart(2, "0")}`;
 }
 
 if (typeof module !== "undefined") {

--- a/public/queue-utils.js
+++ b/public/queue-utils.js
@@ -33,7 +33,17 @@
   }
 
   function adjustIndexOnRemove(currentIndex, removedIndex) {
-    return removedIndex <= currentIndex ? currentIndex - 1 : currentIndex;
+    if (typeof currentIndex !== 'number' || currentIndex < 0) {
+      return currentIndex;
+    }
+    if (typeof removedIndex !== 'number' || removedIndex < 0) {
+      return currentIndex;
+    }
+    if (removedIndex > currentIndex) {
+      return currentIndex;
+    }
+    const nextIndex = currentIndex - 1;
+    return nextIndex >= 0 ? nextIndex : -1;
   }
 
   function previousIndex(currentIndex) {


### PR DESCRIPTION
## Summary
- validate OAuth token exchanges to surface HTTP and parsing failures
- clamp formatted playback times to zero for invalid input values
- guard queue index adjustments and cover new edge cases with tests

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca34f71f8483338b11c69224552466