### PR TITLE
Add Audius discovery API client utilities and tests

### DIFF
--- a/__tests__/audius.test.js
+++ b/__tests__/audius.test.js
@@ -1,0 +1,102 @@
+describe("audius api helper", () => {
+  const noopSleep = async () => {};
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test("fetchDiscoveryNodes validates response and targets discovery endpoint", async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: ["https://discoveryprovider.audius.co", "https://another.example"],
+      }),
+    });
+
+    const {
+      fetchDiscoveryNodes,
+      AUDIUS_DISCOVERY_ENDPOINT,
+    } = require("../audius");
+
+    const hosts = await fetchDiscoveryNodes(mockFetch, { sleep: noopSleep, timeoutMs: 1000 });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      AUDIUS_DISCOVERY_ENDPOINT,
+      expect.objectContaining({
+        method: "GET",
+        headers: { Accept: "application/json" },
+      }),
+    );
+    expect(hosts).toEqual([
+      "https://discoveryprovider.audius.co",
+      "https://another.example",
+    ]);
+  });
+
+  test("fetchDiscoveryNodes retries with exponential backoff before succeeding", async () => {
+    const error = new Error("network down");
+    const mockFetch = jest
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: ["https://dp.audius.co"] }),
+      });
+
+    const { fetchDiscoveryNodes } = require("../audius");
+
+    const hosts = await fetchDiscoveryNodes(mockFetch, {
+      retries: 1,
+      sleep: noopSleep,
+      timeoutMs: 1000,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(hosts).toEqual(["https://dp.audius.co"]);
+  });
+
+  test("fetchDiscoveryNodes throws when discovery payload is invalid", async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: ["not-a-url"] }),
+    });
+
+    const { fetchDiscoveryNodes } = require("../audius");
+
+    await expect(
+      fetchDiscoveryNodes(mockFetch, { sleep: noopSleep, timeoutMs: 1000 }),
+    ).rejects.toThrow(/Invalid url/i);
+  });
+
+  test("pickAudiusHost selects host using provided random function", () => {
+    const { pickAudiusHost } = require("../audius");
+    const hosts = ["h1", "h2", "h3"];
+
+    const selected = pickAudiusHost(hosts, () => 0.65);
+    expect(selected).toBe("h2");
+
+    expect(() => pickAudiusHost([])).toThrow(/No Audius discovery hosts available/);
+  });
+
+  test("buildAudiusTrackUrl constructs canonical track endpoint", () => {
+    const { buildAudiusTrackUrl } = require("../audius");
+    const url = buildAudiusTrackUrl("https://discovery.audius.co", "123", {
+      appName: "Test App",
+      apiKey: "key",
+    });
+    expect(url).toBe(
+      "https://discovery.audius.co/v1/tracks/123?app_name=Test+App&api_key=key",
+    );
+  });
+
+  test("buildAudiusStreamUrl encodes identifiers and omits api key when absent", () => {
+    const { buildAudiusStreamUrl } = require("../audius");
+    const url = buildAudiusStreamUrl("https://discovery.audius.co/", "tr/ack", {
+      appName: "My Player",
+    });
+    expect(url).toBe(
+      "https://discovery.audius.co/v1/tracks/tr%2Fack/stream?app_name=My+Player",
+    );
+  });
+});

--- a/audius.js
+++ b/audius.js
@@ -1,0 +1,312 @@
+const { z } = require("zod");
+
+/**
+ * @typedef {(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>} FetchLike
+ * @typedef {(ms: number) => Promise<void>} SleepFn
+ * @typedef {{ retries?: number; timeoutMs?: number; sleep?: SleepFn }} FetchDiscoveryOptions
+ * @typedef {{ appName: string; apiKey?: string }} AudiusRequestOptions
+ */
+
+const AUDIUS_DISCOVERY_ENDPOINT = "https://api.audius.co";
+const DEFAULT_TIMEOUT_MS = 8000;
+const DEFAULT_RETRIES = 2;
+const INITIAL_BACKOFF_MS = 250;
+
+const discoveryResponseSchema = z.object({
+  data: z.array(z.string().url()),
+});
+
+const fetchOptionsSchema = z.object({
+  retries: z
+    .number()
+    .int()
+    .min(0)
+    .max(5)
+    .optional(),
+  timeoutMs: z
+    .number()
+    .int()
+    .min(0)
+    .max(60000)
+    .optional(),
+});
+
+const requestOptionsSchema = z.object({
+  appName: z.string().trim().min(1, "appName is required"),
+  apiKey: z
+    .string()
+    .trim()
+    .min(1)
+    .optional(),
+});
+
+const hostSchema = z.string().trim().min(1, "host is required");
+const trackIdSchema = z.string().trim().min(1, "trackId is required");
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function defaultSleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * @returns {FetchLike}
+ */
+function getGlobalFetch() {
+  if (typeof fetch === "function") {
+    return fetch.bind(globalThis);
+  }
+  throw new Error("Global fetch is not available; provide a fetch implementation.");
+}
+
+/**
+ * @param {string} rawHost
+ * @returns {string}
+ */
+function normalizeHost(rawHost) {
+  const sanitized = hostSchema.parse(rawHost);
+  let url;
+  try {
+    url = new URL(sanitized);
+  } catch (error) {
+    const err = new Error(`Invalid Audius host: ${sanitized}`);
+    Object.assign(err, { cause: error });
+    throw err;
+  }
+  const pathname = url.pathname.replace(/\/+$/, "");
+  const base = `${url.origin}${pathname}`;
+  return base.endsWith("/") ? base : `${base}/`;
+}
+
+/**
+ * @param {Response} response
+ * @returns {Promise<unknown>}
+ */
+async function safeJsonParse(response) {
+  try {
+    return await response.json();
+  } catch (error) {
+    const err = new Error("Audius discovery response was not valid JSON");
+    Object.assign(err, { cause: error });
+    throw err;
+  }
+}
+
+/**
+ * @param {number} timeoutMs
+ * @returns {{ signal: AbortSignal | undefined; cancel: () => void }}
+ */
+function buildTimeoutAbort(timeoutMs) {
+  if (typeof AbortController !== "function" || timeoutMs <= 0) {
+    return { signal: undefined, cancel: () => {} };
+  }
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  return {
+    signal: controller.signal,
+    cancel: () => clearTimeout(timeoutId),
+  };
+}
+
+/**
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {RequestInfo | URL} url
+ * @param {number} timeoutMs
+ * @returns {Promise<T>}
+ */
+function withManualTimeout(promise, url, timeoutMs) {
+  if (timeoutMs <= 0) {
+    return promise;
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      const timeoutError = new Error(`Request to ${String(url)} timed out after ${timeoutMs}ms`);
+      timeoutError.name = "TimeoutError";
+      reject(timeoutError);
+    }, timeoutMs);
+    promise
+      .then((value) => {
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch((error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+  });
+}
+
+/**
+ * @param {FetchLike} fetchImpl
+ * @param {RequestInfo | URL} url
+ * @param {RequestInit | undefined} options
+ * @param {number} timeoutMs
+ * @returns {Promise<Response>}
+ */
+async function fetchWithTimeout(fetchImpl, url, options, timeoutMs) {
+  const opts = { ...(options || {}) };
+  const canAbort = typeof AbortController === "function";
+  const shouldAbort = canAbort && !opts.signal && timeoutMs > 0;
+  const abort = shouldAbort
+    ? buildTimeoutAbort(timeoutMs)
+    : { signal: opts.signal, cancel: () => {} };
+  if (shouldAbort) {
+    opts.signal = abort.signal;
+  }
+
+  const fetchPromise = fetchImpl(url, opts);
+  const awaited = shouldAbort
+    ? fetchPromise
+    : withManualTimeout(fetchPromise, url, timeoutMs);
+
+  try {
+    return await awaited;
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      const timeoutError = new Error(`Request to ${String(url)} timed out after ${timeoutMs}ms`);
+      timeoutError.name = "TimeoutError";
+      Object.assign(timeoutError, { cause: error });
+      throw timeoutError;
+    }
+    throw error;
+  } finally {
+    abort.cancel();
+  }
+}
+
+/**
+ * @param {FetchLike} [fetchImpl]
+ * @param {FetchDiscoveryOptions} [options]
+ * @returns {Promise<string[]>}
+ */
+async function fetchDiscoveryNodes(fetchImpl, options = {}) {
+  const validated = fetchOptionsSchema.parse({
+    retries: options.retries,
+    timeoutMs: options.timeoutMs,
+  });
+  const retries = validated.retries ?? DEFAULT_RETRIES;
+  const timeoutMs = validated.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const sleep = typeof options.sleep === "function" ? options.sleep : defaultSleep;
+  const fetchFn = typeof fetchImpl === "function" ? fetchImpl : getGlobalFetch();
+
+  let backoff = INITIAL_BACKOFF_MS;
+  /** @type {unknown} */
+  let lastError;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop -- retries run sequentially
+      const response = await fetchWithTimeout(
+        fetchFn,
+        AUDIUS_DISCOVERY_ENDPOINT,
+        {
+          method: "GET",
+          headers: {
+            Accept: "application/json",
+          },
+        },
+        timeoutMs,
+      );
+      if (!response || typeof response.ok !== "boolean") {
+        throw new Error("Audius discovery request returned an invalid response");
+      }
+      if (!response.ok) {
+        throw new Error(`Audius discovery request failed with status ${response.status}`);
+      }
+      // eslint-disable-next-line no-await-in-loop -- parse response before deciding on retry
+      const payload = await safeJsonParse(response);
+      const parsed = discoveryResponseSchema.parse(payload);
+      if (!parsed.data.length) {
+        throw new Error("Audius discovery returned no hosts");
+      }
+      return parsed.data;
+    } catch (error) {
+      lastError = error;
+      if (attempt === retries) {
+        break;
+      }
+      // eslint-disable-next-line no-await-in-loop -- wait between retries for backoff
+      await sleep(backoff);
+      backoff *= 2;
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+  throw new Error("Failed to fetch Audius discovery nodes");
+}
+
+/**
+ * @param {string[]} hosts
+ * @param {() => number} [randomFn]
+ * @returns {string}
+ */
+function pickAudiusHost(hosts, randomFn = Math.random) {
+  const hostList = Array.isArray(hosts) ? hosts : [];
+  if (!hostList.length) {
+    throw new Error("No Audius discovery hosts available");
+  }
+  const rand = typeof randomFn === "function" ? randomFn() : Math.random();
+  const index = Math.min(hostList.length - 1, Math.floor(rand * hostList.length));
+  return hostList[index];
+}
+
+/**
+ * @param {string} host
+ * @param {string} trackId
+ * @param {AudiusRequestOptions} options
+ * @returns {string}
+ */
+function buildAudiusTrackUrl(host, trackId, options) {
+  const { appName, apiKey } = requestOptionsSchema.parse(options || {});
+  const normalizedHost = normalizeHost(host);
+  const validTrackId = trackIdSchema.parse(trackId);
+  const url = new URL(`v1/tracks/${encodeURIComponent(validTrackId)}`, normalizedHost);
+  url.searchParams.set("app_name", appName);
+  if (apiKey) {
+    url.searchParams.set("api_key", apiKey);
+  }
+  return url.toString();
+}
+
+/**
+ * @param {string} host
+ * @param {string} trackId
+ * @param {AudiusRequestOptions} options
+ * @returns {string}
+ */
+function buildAudiusStreamUrl(host, trackId, options) {
+  const { appName, apiKey } = requestOptionsSchema.parse(options || {});
+  const normalizedHost = normalizeHost(host);
+  const validTrackId = trackIdSchema.parse(trackId);
+  const url = new URL(`v1/tracks/${encodeURIComponent(validTrackId)}/stream`, normalizedHost);
+  url.searchParams.set("app_name", appName);
+  if (apiKey) {
+    url.searchParams.set("api_key", apiKey);
+  }
+  return url.toString();
+}
+
+const api = {
+  AUDIUS_DISCOVERY_ENDPOINT,
+  fetchDiscoveryNodes,
+  pickAudiusHost,
+  buildAudiusTrackUrl,
+  buildAudiusStreamUrl,
+};
+
+if (typeof module === "object" && module.exports) {
+  module.exports = api;
+} else {
+  const globalScope = typeof globalThis !== "undefined" ? globalThis : window;
+  /** @type {Record<string, unknown>} */
+  (globalScope).AudiusAPI = api;
+}

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "3.2.5",
     "typescript": "5.4.5"
+  },
+  "dependencies": {
+    "zod": "^4.1.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      zod:
+        specifier: ^4.1.11
+        version: 4.1.11
     devDependencies:
       '@types/jest':
         specifier: 29.5.5
@@ -2128,6 +2132,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
 snapshots:
 
@@ -4782,3 +4789,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zod@4.1.11: {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "types": ["jest", "node"],
     "skipLibCheck": true
   },
-  "include": ["auth.js", "format-time.js", "jest.config.js", "spotify.js"],
+  "include": ["auth.js", "audius.js", "format-time.js", "jest.config.js", "spotify.js"],
   "exclude": ["node_modules", "test", "public", "__tests__"]
 }


### PR DESCRIPTION
## Summary
- add a reusable Audius discovery client with timeouts, retries, and validation
- cover the Audius helper with unit tests and wire it into the TypeScript project config
- add Zod runtime dependency for schema validation

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68de1751dd6c8333af8dad36d6f9f284