### PR TITLE
fix: repair mr.flen dashboard data

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -211,6 +211,30 @@
             Add to Library
           </button>
         </div>
+
+        <dl class="mt-6 grid grid-cols-3 gap-3 max-w-xs" data-aos="fade-up" data-aos-delay="400">
+          <div class="glass-panel px-3 py-2 rounded-xl text-center">
+            <dt class="text-xs text-muted uppercase tracking-wider flex items-center justify-center gap-1">
+              <i data-feather="play" class="w-3 h-3"></i>
+              Plays
+            </dt>
+            <dd id="heroPlayCount" class="mt-1 text-base font-semibold">--</dd>
+          </div>
+          <div class="glass-panel px-3 py-2 rounded-xl text-center">
+            <dt class="text-xs text-muted uppercase tracking-wider flex items-center justify-center gap-1">
+              <i data-feather="heart" class="w-3 h-3 text-rose-500/70"></i>
+              Likes
+            </dt>
+            <dd id="heroLikeCount" class="mt-1 text-base font-semibold">--</dd>
+          </div>
+          <div class="glass-panel px-3 py-2 rounded-xl text-center">
+            <dt class="text-xs text-muted uppercase tracking-wider flex items-center justify-center gap-1">
+              <i data-feather="refresh-cw" class="w-3 h-3"></i>
+              Reposts
+            </dt>
+            <dd id="heroRepostCount" class="mt-1 text-base font-semibold">--</dd>
+          </div>
+        </dl>
       </div>
     </section>
     
@@ -299,7 +323,7 @@
         </h2>
       </div>
       
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 p-4">
+      <div id="trendingGrid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 p-4">
         <div class="glass-panel rounded-xl overflow-hidden group" data-aos="zoom-in" data-aos-delay="100">
           <div class="aspect-square relative">
             <img 
@@ -600,7 +624,7 @@
       "scRedirectUri": "https://your-actual-domain.com/soundcloud-callback",
       "googleClientId": "YOUR_ACTUAL_GOOGLE_CLIENT_ID_HERE",
       "googleRedirectUri": "https://your-actual-domain.com/google-callback",
-      "mrflens": { "audiusHandle": "mrflen", "soundcloudUsername": "Mr.FLEN" }
+      "mrflens": { "audiusHandle": "mr.flen", "soundcloudUsername": "Mr.FLEN" }
     }
   </script>
   
@@ -608,6 +632,59 @@
   <script>
     const AUDIUS_API_KEY = "922e6edcae9856000bf6814a1ee5745bfb57734";
     const AUDIUS_BASE_URL = "https://discoveryprovider.audius.co/v1";
+    const CONFIG = JSON.parse(document.getElementById('config').textContent);
+    const DEFAULT_ARTWORK = 'https://audius-content-6.cultur3stake.com/content/01K0PYMD8X6ZA6JNCDWMWD4510/480x480.jpg';
+
+    function getMrFlenHandle() {
+      return (CONFIG?.mrflens?.audiusHandle || 'mr.flen').trim();
+    }
+
+    function formatCount(value) {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric) || numeric < 0) {
+        return '0';
+      }
+      if (numeric >= 1_000_000) {
+        return `${(numeric / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+      }
+      if (numeric >= 1_000) {
+        return `${(numeric / 1_000).toFixed(1).replace(/\.0$/, '')}k`;
+      }
+      return `${Math.round(numeric)}`;
+    }
+
+    async function fetchUserByHandle(handle) {
+      const target = handle?.trim();
+      if (!target) {
+        return null;
+      }
+
+      const handleUrl = `${AUDIUS_BASE_URL}/users/handle/${encodeURIComponent(target)}?app_name=MrFLEN`;
+      try {
+        const res = await fetch(handleUrl, { headers: { Accept: 'application/json' } });
+        if (res.ok) {
+          const payload = await res.json();
+          if (payload?.data) {
+            return payload.data;
+          }
+        }
+      } catch (error) {
+        console.warn('Failed to resolve user by handle endpoint', error);
+      }
+
+      try {
+        const searchUrl = `${AUDIUS_BASE_URL}/users/search?query=${encodeURIComponent(target)}&app_name=MrFLEN`;
+        const response = await fetch(searchUrl, { headers: { Accept: 'application/json' } });
+        if (!response.ok) {
+          return null;
+        }
+        const data = await response.json();
+        return data?.data?.find((user) => user?.handle === target || user?.handle_lc === target.toLowerCase()) || null;
+      } catch (error) {
+        console.error('Error searching for user', error);
+        return null;
+      }
+    }
     
     // Initialize animations and icons
     document.addEventListener('DOMContentLoaded', async () => {
@@ -754,25 +831,29 @@
     
     // Fetch trending tracks from Audius
     async function fetchTrendingTracks() {
+      const trendingContainer = document.getElementById('trendingGrid');
+      if (!trendingContainer) {
+        return;
+      }
       try {
         const response = await fetch(`${AUDIUS_BASE_URL}/tracks/trending?app_name=MrFLEN`, {
           headers: {
-            'Accept': 'application/json'
+            Accept: 'application/json'
           }
         });
-        
+
         if (!response.ok) throw new Error('Failed to fetch trending tracks');
-        
+
         const data = await response.json();
-        const trendingContainer = document.querySelector('.grid.grid-cols-1');
-        
+
         if (data.data && data.data.length > 0) {
           trendingContainer.innerHTML = '';
-          
+
           data.data.slice(0, 4).forEach((track, index) => {
             const trackElement = createTrackCard(track, index);
             trendingContainer.appendChild(trackElement);
           });
+          feather.replace();
         }
       } catch (error) {
         console.error('Error fetching trending tracks:', error);
@@ -782,43 +863,45 @@
     // Fetch Mr.FLEN tracks
     async function fetchMrFlenTracks() {
       try {
-        // First, get Mr.FLEN user ID
-        const userResponse = await fetch(`${AUDIUS_BASE_URL}/users/search?query=mrflen&app_name=MrFLEN`, {
+        const handle = getMrFlenHandle();
+        const mrFlenUser = await fetchUserByHandle(handle);
+        if (!mrFlenUser) {
+          console.warn('Unable to resolve Mr.FLEN user profile for handle:', handle);
+          return;
+        }
+
+        const tracksResponse = await fetch(`${AUDIUS_BASE_URL}/users/${mrFlenUser.id}/tracks?app_name=MrFLEN`, {
           headers: {
-            'Accept': 'application/json'
+            Accept: 'application/json'
           }
         });
-        
-        if (!userResponse.ok) throw new Error('Failed to search for Mr.FLEN');
-        
-        const userData = await userResponse.json();
-        if (userData.data && userData.data.length > 0) {
-          const mrFlenUser = userData.data[0];
-          
-          // Get tracks by Mr.FLEN
-          const tracksResponse = await fetch(`${AUDIUS_BASE_URL}/users/${mrFlenUser.id}/tracks?app_name=MrFLEN`, {
-            headers: {
-              'Accept': 'application/json'
-            }
-          });
-          
-          if (!tracksResponse.ok) throw new Error('Failed to fetch Mr.FLEN tracks');
-          
-          const tracksData = await tracksResponse.json();
-          const libraryList = document.getElementById('libraryList');
-          
-          if (tracksData.data && tracksData.data.length > 0) {
-            libraryList.innerHTML = '';
-            
-            tracksData.data.slice(0, 3).forEach(track => {
+
+        if (!tracksResponse.ok) throw new Error('Failed to fetch Mr.FLEN tracks');
+
+        const tracksData = await tracksResponse.json();
+        const libraryList = document.getElementById('libraryList');
+        const tracks = Array.isArray(tracksData?.data) ? tracksData.data.slice() : [];
+
+        if (tracks.length === 0) {
+          return;
+        }
+
+        tracks.sort((a, b) => (b?.play_count || 0) - (a?.play_count || 0));
+
+        if (libraryList) {
+          libraryList.innerHTML = '';
+
+          tracks
+            .filter((track) => !track?.is_unlisted)
+            .slice(0, 3)
+            .forEach((track) => {
               const listItem = createLibraryListItem(track);
               libraryList.appendChild(listItem);
             });
-            
-            // Update hero section with the first track
-            updateHeroSection(tracksData.data[0]);
-          }
+          feather.replace();
         }
+
+        updateHeroSection(tracks[0], mrFlenUser);
       } catch (error) {
         console.error('Error fetching Mr.FLEN tracks:', error);
       }
@@ -831,9 +914,9 @@
       card.setAttribute('data-aos', 'zoom-in');
       card.setAttribute('data-aos-delay', `${(index + 1) * 100}`);
       
-      const artworkUrl = track.artwork && track.artwork['480x480'] 
-        ? track.artwork['480x480'] 
-        : 'https://audius-content-6.cultur3stake.com/content/01K0PYMD8X6ZA6JNCDWMWD4510/480x480.jpg';
+      const artworkUrl = track.artwork && track.artwork['480x480']
+        ? track.artwork['480x480']
+        : DEFAULT_ARTWORK;
       
       card.innerHTML = `
         <div class="aspect-square relative">
@@ -849,24 +932,36 @@
           </div>
           <button 
             class="glass-panel w-12 h-12 rounded-full flex items-center justify-center absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transform scale-90 group-hover:scale-100 transition-all duration-300"
-            onclick="playTrack('${track.id}', '${track.title}', '${track.user.name}', '${artworkUrl}')"
+            data-role="play-track"
           >
             <i data-feather="play" class="w-5 h-5"></i>
           </button>
         </div>
-        
+
         <div class="p-3 flex items-center justify-between">
           <div class="text-xs flex items-center gap-1 text-muted">
             <i data-feather="play" class="w-3 h-3"></i>
-            <span>${track.play_count ? Math.round(track.play_count / 1000) + 'k' : '0'}</span>
+            <span>${formatCount(track.play_count)}</span>
           </div>
           <div class="text-xs flex items-center gap-1 text-muted">
             <i data-feather="heart" class="w-3 h-3 text-rose-500/70"></i>
-            <span>${track.favorite_count ? Math.round(track.favorite_count / 1000) + 'k' : '0'}</span>
+            <span>${formatCount(track.favorite_count)}</span>
           </div>
         </div>
       `;
-      
+
+      const playButton = card.querySelector('[data-role="play-track"]');
+      if (playButton) {
+        playButton.addEventListener('click', () => {
+          playTrack(
+            track.id,
+            track.title,
+            track.user?.name || 'Unknown Artist',
+            artworkUrl
+          );
+        });
+      }
+
       return card;
     }
     
@@ -875,9 +970,9 @@
       const li = document.createElement('li');
       li.className = 'track-item glass-panel px-3 py-2 rounded-xl flex items-center gap-3 cursor-pointer group';
       
-      const artworkUrl = track.artwork && track.artwork['150x150'] 
-        ? track.artwork['150x150'] 
-        : 'https://audius-content-6.cultur3stake.com/content/01K0PYMD8X6ZA6JNCDWMWD4510/480x480.jpg';
+      const artworkUrl = track.artwork && track.artwork['150x150']
+        ? track.artwork['150x150']
+        : DEFAULT_ARTWORK;
       
       li.innerHTML = `
         <div class="w-12 h-12 rounded-lg bg-gradient-to-br from-brand/30 to-accent/30 overflow-hidden">
@@ -892,27 +987,45 @@
           <div class="text-xs text-muted truncate">${track.user.name}</div>
         </div>
         <button class="glass-panel w-8 h-8 flex items-center justify-center rounded-full group-hover:opacity-100 opacity-0 transition-opacity"
-                onclick="playTrack('${track.id}', '${track.title}', '${track.user.name}', '${artworkUrl}')">
+                data-role="play-track">
           <i data-feather="play" class="w-4 h-4"></i>
         </button>
       `;
-      
+
+      const playButton = li.querySelector('[data-role="play-track"]');
+      const play = () => playTrack(
+        track.id,
+        track.title,
+        track.user?.name || 'Unknown Artist',
+        artworkUrl
+      );
+      if (playButton) {
+        playButton.addEventListener('click', (event) => {
+          event.stopPropagation();
+          play();
+        });
+      }
+      li.addEventListener('click', play);
+
       return li;
     }
     
     // Update hero section with track data
-    function updateHeroSection(track) {
+    function updateHeroSection(track, user) {
       if (!track) return;
 
       const heroTitle = document.getElementById('heroTitle');
       const heroImage = document.getElementById('heroImage');
       const heroArtist = document.getElementById('heroArtist');
       const playButton = document.getElementById('heroPlayButton');
+      const heroPlayCount = document.getElementById('heroPlayCount');
+      const heroLikeCount = document.getElementById('heroLikeCount');
+      const heroRepostCount = document.getElementById('heroRepostCount');
       const fallbackArtwork = heroImage?.dataset?.fallbackArtwork
-        || 'https://audius-content-6.cultur3stake.com/content/01K0PYMD8X6ZA6JNCDWMWD4510/480x480.jpg';
+        || DEFAULT_ARTWORK;
 
       if (heroTitle) heroTitle.textContent = track.title || 'Untitled';
-      if (heroArtist) heroArtist.textContent = track.user?.name || 'Unknown Artist';
+      if (heroArtist) heroArtist.textContent = user?.name || track.user?.name || 'Unknown Artist';
 
       const artwork = (track.artwork && track.artwork['480x480']) || fallbackArtwork;
       if (heroImage) heroImage.src = artwork;
@@ -921,9 +1034,19 @@
         playButton.onclick = () => playTrack(
           track.id,
           track.title,
-          track.user?.name || 'Unknown Artist',
+          user?.name || track.user?.name || 'Unknown Artist',
           artwork
         );
+      }
+
+      if (heroPlayCount) {
+        heroPlayCount.textContent = formatCount(track.play_count);
+      }
+      if (heroLikeCount) {
+        heroLikeCount.textContent = formatCount(track.favorite_count);
+      }
+      if (heroRepostCount) {
+        heroRepostCount.textContent = formatCount(track.repost_count);
       }
     }
     
@@ -978,16 +1101,20 @@
       
       connectSCButton.addEventListener('click', () => {
         // SoundCloud OAuth 2.0 flow - compliant with security policies
-        const config = JSON.parse(document.getElementById('config').textContent);
-        const clientId = config.scClientId;
-        const redirectUri = encodeURIComponent(config.scRedirectUri);
+        const clientId = CONFIG.scClientId;
+        const redirectUri = encodeURIComponent(CONFIG.scRedirectUri || '');
         const scope = encodeURIComponent('non-expiring');
         const responseType = 'code';
         const state = generateStateParameter(); // CSRF protection
-        
+
         // Store state in session storage for validation
         sessionStorage.setItem('sc_oauth_state', state);
-        
+
+        if (!clientId || !CONFIG.scRedirectUri) {
+          alert('SoundCloud auth not configured.');
+          return;
+        }
+
         const authUrl = `https://soundcloud.com/connect?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=${responseType}&scope=${scope}&state=${state}`;
         
         // Redirect to SoundCloud auth (not popup for better security)
@@ -1044,18 +1171,22 @@
       
       connectGoogleButton.addEventListener('click', () => {
         // Google OAuth 2.0 flow - compliant with security policies
-        const config = JSON.parse(document.getElementById('config').textContent);
-        const clientId = config.googleClientId;
-        const redirectUri = encodeURIComponent(config.googleRedirectUri);
+        const clientId = CONFIG.googleClientId;
+        const redirectUri = encodeURIComponent(CONFIG.googleRedirectUri || '');
         const scope = encodeURIComponent('email profile');
         const responseType = 'code';
         const state = generateStateParameter(); // CSRF protection
         const nonce = generateStateParameter(); // Replay attack protection
-        
+
         // Store state and nonce in session storage for validation
         sessionStorage.setItem('google_oauth_state', state);
         sessionStorage.setItem('google_oauth_nonce', nonce);
-        
+
+        if (!clientId || !CONFIG.googleRedirectUri) {
+          alert('Google auth not configured.');
+          return;
+        }
+
         const authUrl = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=${responseType}&scope=${scope}&state=${state}&nonce=${nonce}&prompt=select_account`;
         
         // Redirect to Google auth (not popup for better security)


### PR DESCRIPTION
## Summary
- resolve Mr.FLEN profile via handle endpoint so dashboard lists the correct tracks
- surface real play, like, and repost counts for hero and trending cards with resilient formatting
- refresh dynamic cards with stable selectors, fallbacks, and icon hydration for consistent UI

## Testing
- not run (front-end changes only)


------
https://chatgpt.com/codex/tasks/task_e_68de41a063508333b68d068c05d9261e